### PR TITLE
feat: use small HTTP dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/pify": "^3.0.0",
     "@types/protobufjs": "^5.0.31",
     "@types/proxyquire": "^1.3.28",
-    "@types/request": "^2.0.8",
+    "@types/request": "^2.47.1",
     "@types/semver": "^5.4.0",
     "@types/shimmer": "^1.0.1",
     "@types/tmp": "0.0.33",
@@ -103,10 +103,10 @@
     "hex2dec": "^1.0.1",
     "is": "^3.2.0",
     "methods": "^1.1.1",
-    "request": "^2.83.0",
     "require-in-the-middle": "^3.0.0",
     "semver": "^5.4.1",
     "shimmer": "^1.2.0",
+    "teeny-request": "^3.9.0",
     "uuid": "^3.0.1"
   }
 }

--- a/src/trace-writer.ts
+++ b/src/trace-writer.ts
@@ -19,7 +19,8 @@ import {AxiosError} from 'axios';
 import * as gcpMetadata from 'gcp-metadata';
 import {OutgoingHttpHeaders} from 'http';
 import * as os from 'os';
-import * as request from 'request';
+import * as r from 'request';  // Only for type declarations.
+import {teenyRequest} from 'teeny-request';
 
 import {Constants} from './constants';
 import {Logger} from './logger';
@@ -79,7 +80,7 @@ export class TraceWriter extends common.Service {
       private readonly logger: Logger) {
     super(
         {
-          requestModule: request,
+          requestModule: teenyRequest as typeof r,
           packageJson: pjson,
           projectIdRequired: false,
           baseUrl: 'https://cloudtrace.googleapis.com/v1',

--- a/test/test-trace-writer.ts
+++ b/test/test-trace-writer.ts
@@ -19,7 +19,7 @@ import * as assert from 'assert';
 import {OutgoingHttpHeaders} from 'http';
 import * as nock from 'nock';
 import * as os from 'os';
-import {Response} from 'request';
+import {Response} from 'request';  // Only for type declarations.
 import * as shimmer from 'shimmer';
 
 import {SpanKind, Trace} from '../src/trace';


### PR DESCRIPTION
Use teenyRequest instead of request. This saves 900 ms at
startup time.

Improve load time from 1500 ms to 650 ms. 

Before `request`:
![screen shot 2018-09-07 at 9 27 55 pm](https://user-images.githubusercontent.com/101553/45248912-40402280-b2e5-11e8-83f4-b2ffd7d2f3a6.png)

After with `teenyRequest`:
![screen shot 2018-09-07 at 9 28 52 pm](https://user-images.githubusercontent.com/101553/45248916-46ce9a00-b2e5-11e8-90f7-f150566d7dc8.png)
