### PR TITLE
feat: emit an error log on potential memory leak scenario

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -25,26 +25,6 @@ export type CLSMechanism =
 /** Available configuration options. */
 export interface Config {
   /**
-   * The trace context propagation mechanism to use. The following options are
-   * available:
-   * - 'async-hooks' uses an implementation of CLS on top of the Node core
-   *   `async_hooks` module in Node 8+. This option should not be used if the
-   *   Node binary version requirements are not met.
-   * - 'async-listener' uses an implementation of CLS on top of the
-   *   `continuation-local-storage` module.
-   * - 'auto' behaves like 'async-hooks' on Node 8+, and 'async-listener'
-   *   otherwise.
-   * - 'none' disables CLS completely.
-   * - 'singular' allows one root span to exist at a time. This option is meant
-   *   to be used internally by Google Cloud Functions, or in any other
-   *   environment where it is guaranteed that only one request is being served
-   *   at a time.
-   * The 'auto' mechanism is used by default if this configuration option is
-   * not explicitly set.
-   */
-  clsMechanism?: CLSMechanism;
-
-  /**
    * Log levels: 0=disabled, 1=error, 2=warn, 3=info, 4=debug
    * The value of GCLOUD_TRACE_LOGLEVEL takes precedence over this value.
    */
@@ -69,6 +49,34 @@ export interface Config {
    * as an argument, and its return value will be used as the span name.
    */
   rootSpanNameOverride?: string|((name: string) => string);
+
+  /**
+   * The trace context propagation mechanism to use. The following options are
+   * available:
+   * - 'async-hooks' uses an implementation of CLS on top of the Node core
+   *   `async_hooks` module in Node 8+. This option should not be used if the
+   *   Node binary version requirements are not met.
+   * - 'async-listener' uses an implementation of CLS on top of the
+   *   `continuation-local-storage` module.
+   * - 'auto' behaves like 'async-hooks' on Node 8+, and 'async-listener'
+   *   otherwise.
+   * - 'none' disables CLS completely.
+   * - 'singular' allows one root span to exist at a time. This option is meant
+   *   to be used internally by Google Cloud Functions, or in any other
+   *   environment where it is guaranteed that only one request is being served
+   *   at a time.
+   * The 'auto' mechanism is used by default if this configuration option is
+   * not explicitly set.
+   */
+  clsMechanism?: CLSMechanism;
+
+  /**
+   * The number of local spans per trace to allow before emitting a warning.
+   * An excessive number of spans per trace may suggest a memory leak.
+   * This value should be 1-2x the estimated maximum number of RPCs made on
+   * behalf of a single incoming request.
+   */
+  spansPerTraceSoftLimit?: number;
 
   /**
    * The maximum number of characters reported on a label value. This value
@@ -197,11 +205,12 @@ export interface Config {
  * user-provided value will be used to extend the default value.
  */
 export const defaultConfig = {
-  clsMechanism: 'auto' as CLSMechanism,
   logLevel: 1,
   enabled: true,
   enhancedDatabaseReporting: false,
   rootSpanNameOverride: (name: string) => name,
+  clsMechanism: 'auto' as CLSMechanism,
+  spansPerTraceSoftLimit: 25,
   maximumLabelValueSize: 512,
   plugins: {
     // enable all by default

--- a/src/config.ts
+++ b/src/config.ts
@@ -210,7 +210,7 @@ export const defaultConfig = {
   enhancedDatabaseReporting: false,
   rootSpanNameOverride: (name: string) => name,
   clsMechanism: 'auto' as CLSMechanism,
-  spansPerTraceSoftLimit: 25,
+  spansPerTraceSoftLimit: 200,
   maximumLabelValueSize: 512,
   plugins: {
     // enable all by default

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,11 +72,18 @@ export interface Config {
 
   /**
    * The number of local spans per trace to allow before emitting a warning.
-   * An excessive number of spans per trace may suggest a memory leak.
+   * An unexpectedly large number of spans per trace may suggest a memory leak.
    * This value should be 1-2x the estimated maximum number of RPCs made on
    * behalf of a single incoming request.
    */
   spansPerTraceSoftLimit?: number;
+
+  /**
+   * The maximum number of local spans per trace to allow in total. Creating
+   * more spans will cause the agent to log an error. (This limit does not apply
+   * when using RootSpan to create child spans.)
+   */
+  spansPerTraceHardLimit?: number;
 
   /**
    * The maximum number of characters reported on a label value. This value
@@ -211,6 +218,7 @@ export const defaultConfig = {
   rootSpanNameOverride: (name: string) => name,
   clsMechanism: 'auto' as CLSMechanism,
   spansPerTraceSoftLimit: 200,
+  spansPerTraceHardLimit: 1000,
   maximumLabelValueSize: 512,
   plugins: {
     // enable all by default

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,7 +71,7 @@ export interface Config {
   clsMechanism?: CLSMechanism;
 
   /**
-   * The number of local spans per trace to allow before emitting a warning.
+   * The number of local spans per trace to allow before emitting an error log.
    * An unexpectedly large number of spans per trace may suggest a memory leak.
    * This value should be 1-2x the estimated maximum number of RPCs made on
    * behalf of a single incoming request.
@@ -80,8 +80,10 @@ export interface Config {
 
   /**
    * The maximum number of local spans per trace to allow in total. Creating
-   * more spans will cause the agent to log an error. (This limit does not apply
-   * when using RootSpan to create child spans.)
+   * more spans in a single trace will cause the agent to log an error, and such
+   * spans will be dropped. (This limit does not apply when using a RootSpan
+   * instance to create child spans.)
+   * This value should be greater than spansPerTraceSoftLimit.
    */
   spansPerTraceHardLimit?: number;
 

--- a/src/trace-api.ts
+++ b/src/trace-api.ts
@@ -238,7 +238,7 @@ export class StackdriverTracer implements Tracer {
         // with continuously growing number of child spans. The second case
         // seems to have some value, but isn't representable. The user probably
         // needs a custom outer span that encompasses the entirety of work.
-        this.logger!.warn(`TraceApi#createChildSpan: [${
+        this.logger!.error(`TraceApi#createChildSpan: [${
             this.pluginName}] Creating phantom child span [${
             options.name}] because root span [${
             rootSpan.span.name}] was already closed.`);
@@ -254,6 +254,11 @@ export class StackdriverTracer implements Tracer {
             rootSpan.span.name}] has reached a limit of ${
             this.config!
                 .spansPerTraceHardLimit} spans. This is likely a memory leak.`);
+        this.logger!.error([
+          'TraceApi#createChildSpan: Please see',
+          'https://github.com/googleapis/cloud-trace-nodejs/wiki',
+          'for details and suggested actions.'
+        ].join(' '));
         return UNCORRELATED_CHILD_SPAN;
       }
       if (rootSpan.trace.spans.length === this.config!.spansPerTraceSoftLimit) {
@@ -271,6 +276,11 @@ export class StackdriverTracer implements Tracer {
             rootSpan.span.name}] to contain more than ${
             this.config!
                 .spansPerTraceSoftLimit} spans. This is likely a memory leak.`);
+        this.logger!.error([
+          'TraceApi#createChildSpan: Please see',
+          'https://github.com/googleapis/cloud-trace-nodejs/wiki',
+          'for details and suggested actions.'
+        ].join(' '));
       }
       // Create a new child span and return it.
       const childContext = rootSpan.createChildSpan({

--- a/src/trace-api.ts
+++ b/src/trace-api.ts
@@ -247,7 +247,12 @@ export class StackdriverTracer implements Tracer {
         // As in the previous case, a root span with a large number of child
         // spans suggests a memory leak stemming from context confusion. This
         // is likely due to userspace task queues or Promise implementations.
-        this.logger!.warn(`TraceApi#createChildSpan: [${
+
+        // Note that since child spans can be created by users directly on a
+        // RootSpanData instance, this block might be skipped because it only
+        // checks equality -- this is OK because no automatic tracing plugin
+        // uses the RootSpanData API directly.
+        this.logger!.error(`TraceApi#createChildSpan: [${
             this.pluginName}] Adding child span [${
             options.name}] will cause the trace with root span [${
             rootSpan.span.name}] to contain more than ${

--- a/test/plugins/common.ts
+++ b/test/plugins/common.ts
@@ -69,7 +69,8 @@ shimmer.wrap(trace, 'start', function(original) {
       enhancedDatabaseReporting: false,
       ignoreContextHeader: false,
       rootSpanNameOverride: (name: string) => name,
-      samplingRate: 0
+      samplingRate: 0,
+      spansPerTraceSoftLimit: Infinity
     }, new TestLogger());
     testTraceAgent.policy = new TracingPolicy.TraceAllPolicy();
     return result;

--- a/test/plugins/common.ts
+++ b/test/plugins/common.ts
@@ -70,7 +70,8 @@ shimmer.wrap(trace, 'start', function(original) {
       ignoreContextHeader: false,
       rootSpanNameOverride: (name: string) => name,
       samplingRate: 0,
-      spansPerTraceSoftLimit: Infinity
+      spansPerTraceSoftLimit: Infinity,
+      spansPerTraceHardLimit: Infinity
     }, new TestLogger());
     testTraceAgent.policy = new TracingPolicy.TraceAllPolicy();
     return result;

--- a/test/test-plugin-loader.ts
+++ b/test/test-plugin-loader.ts
@@ -48,7 +48,8 @@ describe('Trace Plugin Loader', () => {
               enhancedDatabaseReporting: false,
               ignoreContextHeader: false,
               rootSpanNameOverride: (name: string) => name,
-              projectId: '0'
+              projectId: '0',
+              spansPerTraceSoftLimit: Infinity
             },
             config),
         logger);

--- a/test/test-plugin-loader.ts
+++ b/test/test-plugin-loader.ts
@@ -49,7 +49,8 @@ describe('Trace Plugin Loader', () => {
               ignoreContextHeader: false,
               rootSpanNameOverride: (name: string) => name,
               projectId: '0',
-              spansPerTraceSoftLimit: Infinity
+              spansPerTraceSoftLimit: Infinity,
+              spansPerTraceHardLimit: Infinity
             },
             config),
         logger);

--- a/test/test-trace-api.ts
+++ b/test/test-trace-api.ts
@@ -39,7 +39,8 @@ describe('Trace Interface', () => {
               enhancedDatabaseReporting: false,
               ignoreContextHeader: false,
               rootSpanNameOverride: (name: string) => name,
-              samplingRate: 0
+              samplingRate: 0,
+              spansPerTraceSoftLimit: Infinity
             },
             config),
         logger);


### PR DESCRIPTION
Given that the scenario #838 is likely caused by context confusion on long-running requests, this warning should help us determine whether a memory leak is due to an intrinsic design detail to the agent, or context confusion. Emitting this warning is a clear sign of the latter (the remedy would be to identify the userspace queueing mechanism that breaks context, and patch it/request that it support async resources).