### PR TITLE
fix: enable tracing on original client method names

### DIFF
--- a/test/plugins/common.ts
+++ b/test/plugins/common.ts
@@ -30,6 +30,10 @@ if (semver.satisfies(process.version, '>=8')) {
   // Monkeypatch Mocha's it() to create a fresh context with each test case.
   var oldIt = global.it;
   global.it = Object.assign(function it(title, fn) {
+    // it.skip calls it without a function argument
+    if (!fn) {
+      return oldIt.call(this, title);
+    }
     function wrappedFn() {
       if (cls.exists()) {
         return cls.get().runWithContext(() => fn.apply(this, arguments), TraceCLS.UNCORRELATED);


### PR DESCRIPTION
Fixes #873

Since gRPC 1.7 the original, capitalized name of a method is a synonym for the lower-cased version. We didn't trace these methods before, so this PR enables tracing for those methods.