### PR TITLE
fix: add log level to logger prefix

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -65,7 +65,8 @@ export class Logger {
 
     this.logger = consoleLogLevel({
       stderr: true,
-      prefix: opts && opts.tag ? opts.tag : 'unknown',
+      prefix: `${opts && opts.tag ? opts.tag : 'unknown'} ${
+          levelName.toUpperCase()}`,
       level: levelName as ConsoleLogLevel
     });
   }


### PR DESCRIPTION
The new `Logger` class doesn't include `ERROR`/`WARN` etc to allow users to distinguish log levels... this PR fixes this.