### PR TITLE
refactor: improve internal TraceWriter API

### DIFF
--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -134,7 +134,7 @@ export class RootSpanData extends BaseSpanData implements types.RootSpan {
 
   endSpan(timestamp?: Date) {
     super.endSpan(timestamp);
-    traceWriter.get().writeSpan(this.trace);
+    traceWriter.get().writeTrace(this.trace);
   }
 }
 

--- a/src/trace-writer.ts
+++ b/src/trace-writer.ts
@@ -235,7 +235,7 @@ export class TraceWriter extends common.Service {
    *
    * @param trace The trace to be queued.
    */
-  writeSpan(trace: Trace) {
+  writeTrace(trace: Trace) {
     for (const span of trace.spans) {
       if (span.endTime === '') {
         span.endTime = (new Date()).toISOString();
@@ -248,29 +248,21 @@ export class TraceWriter extends common.Service {
         Object.assign(spanData.labels, this.defaultLabels);
       }
     });
-    this.queueTrace(trace);
-  }
 
-  /**
-   * Buffers the provided trace to be published.
-   *
-   * @private
-   * @param trace The trace to be queued.
-   */
-  queueTrace(trace: Trace) {
     const afterProjectId = (projectId: string) => {
       trace.projectId = projectId;
       this.buffer.push(JSON.stringify(trace));
       this.logger.info(
-          `TraceWriter#queueTrace: buffer.size = ${this.buffer.length}`);
+          `TraceWriter#writeTrace: buffer.size = ${this.buffer.length}`);
 
       // Publish soon if the buffer is getting big
       if (this.buffer.length >= this.config.bufferSize) {
         this.logger.info(
-            'TraceWriter#queueTrace: Trace buffer full, flushing.');
+            'TraceWriter#writeTrace: Trace buffer full, flushing.');
         setImmediate(() => this.flushBuffer());
       }
     };
+
     // TODO(kjin): We should always be following the 'else' path.
     // Any test that doesn't mock the Trace Writer will assume that traces get
     // buffered synchronously. We need to refactor those tests to remove that

--- a/src/trace-writer.ts
+++ b/src/trace-writer.ts
@@ -282,12 +282,10 @@ export class TraceWriter extends common.Service {
   }
 
   /**
-   * Flushes the buffer of traces at a regular interval
-   * controlled by the flushDelay property of this
-   * TraceWriter's config.
-   * @private
+   * Flushes the buffer of traces at a regular interval controlled by the
+   * flushDelay property of this TraceWriter's config.
    */
-  scheduleFlush() {
+  private scheduleFlush() {
     this.logger.info('TraceWriter#scheduleFlush: Performing periodic flush.');
     this.flushBuffer();
 
@@ -306,9 +304,8 @@ export class TraceWriter extends common.Service {
 
   /**
    * Serializes the buffered traces to be published asynchronously.
-   * @private
    */
-  flushBuffer() {
+  private flushBuffer() {
     if (this.buffer.length === 0) {
       return;
     }
@@ -322,10 +319,9 @@ export class TraceWriter extends common.Service {
 
   /**
    * Publishes flushed traces to the network.
-   * @private
    * @param json The stringified json representation of the queued traces.
    */
-  publish(json: string) {
+  protected publish(json: string) {
     const hostname = 'cloudtrace.googleapis.com';
     const uri = `https://${hostname}/v1/projects/${this.projectId}/traces`;
     const options = {method: 'PATCH', uri, body: json, headers};

--- a/src/trace-writer.ts
+++ b/src/trace-writer.ts
@@ -141,11 +141,10 @@ export class TraceWriter extends common.Service {
       }
       this.scheduleFlush();
     };
-    const [hostname, instanceId] = await Promise.all([
+    const [hostname, instanceId, _] = await Promise.all([
       this.getHostname(), this.getInstanceId(), getProjectIdAndScheduleFlush()
     ]);
-    // tslint:disable-next-line:no-any
-    const addDefaultLabel = (key: string, value: any) => {
+    const addDefaultLabel = (key: string, value: string|number) => {
       this.defaultLabels[key] = `${value}`;
     };
     this.defaultLabels = {};
@@ -189,7 +188,7 @@ export class TraceWriter extends common.Service {
     }
   }
 
-  private async getInstanceId(): Promise<string|null> {
+  private async getInstanceId(): Promise<number|null> {
     try {
       return await gcpMetadata.instance({property: 'id', headers});
     } catch (err) {

--- a/src/trace-writer.ts
+++ b/src/trace-writer.ts
@@ -141,7 +141,9 @@ export class TraceWriter extends common.Service {
       }
       this.scheduleFlush();
     };
-    const [hostname, instanceId, _] = await Promise.all([
+    // getProjectIdAndScheduleFlush has no return value, so no need to capture
+    // it on the left-hand side.
+    const [hostname, instanceId] = await Promise.all([
       this.getHostname(), this.getInstanceId(), getProjectIdAndScheduleFlush()
     ]);
     const addDefaultLabel = (key: string, value: string|number) => {

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -114,13 +114,11 @@ export class Tracing implements Component {
       this.disable();
       return;
     }
-    traceWriter.get().initialize((err) => {
-      if (err) {
-        this.logger.error(
-            'StackdriverTracer#start: Disabling the Trace Agent for the',
-            `following reason: ${err.message}`);
-        this.disable();
-      }
+    traceWriter.get().initialize().catch((err) => {
+      this.logger.error(
+          'StackdriverTracer#start: Disabling the Trace Agent for the',
+          `following reason: ${err.message}`);
+      this.disable();
     });
     cls.get().enable();
     this.traceAgent.enable(this.config, this.logger);

--- a/test/plugins/common.ts
+++ b/test/plugins/common.ts
@@ -183,7 +183,7 @@ function createChildSpan(cb, duration) {
 }
 
 function installNoopTraceWriter() {
-  traceWriter.get().writeSpan = function() {};
+  traceWriter.get().writeTrace = function() {};
 }
 
 function avoidTraceWriterAuth() {

--- a/test/test-span-data.ts
+++ b/test/test-span-data.ts
@@ -28,7 +28,7 @@ import {wait} from './utils';
 
 describe('SpanData', () => {
   class CaptureSpanTraceWriter extends TraceWriter {
-    writeSpan(trace: Trace) {
+    writeTrace(trace: Trace) {
       assert.strictEqual(capturedTrace, null);
       capturedTrace = trace;
     }

--- a/test/test-trace-api.ts
+++ b/test/test-trace-api.ts
@@ -47,15 +47,15 @@ describe('Trace Interface', () => {
     return result;
   }
 
-  before((done) => {
+  before(() => {
     testTraceModule.setCLSForTest(TraceCLS);
     cls.create({mechanism: TraceCLSMechanism.ASYNC_LISTENER}, logger).enable();
-    traceWriter
+    return traceWriter
         .create(
             Object.assign(
                 {[FORCE_NEW]: true, projectId: 'project-1'}, defaultConfig),
             logger)
-        .initialize(done);
+        .initialize();
   });
 
   after(() => {

--- a/test/test-trace-uncaught-exception.ts
+++ b/test/test-trace-uncaught-exception.ts
@@ -52,7 +52,7 @@ describe('Trace Writer', () => {
       super(config, logger);
       // Don't run the risk of auto-flushing
       this.getConfig().bufferSize = Infinity;
-      this.queueTrace(autoQueuedTrace);
+      this.writeTrace(autoQueuedTrace);
     }
 
     publish(json: string) {

--- a/test/test-trace-uncaught-exception.ts
+++ b/test/test-trace-uncaught-exception.ts
@@ -55,7 +55,7 @@ describe('Trace Writer', () => {
       this.writeTrace(autoQueuedTrace);
     }
 
-    publish(json: string) {
+    protected publish(json: string) {
       capturedPublishedTraces = json;
     }
   }

--- a/test/test-trace-uncaught-exception.ts
+++ b/test/test-trace-uncaught-exception.ts
@@ -17,6 +17,7 @@
 import * as assert from 'assert';
 
 import {Logger} from '../src/logger';
+import {Trace} from '../src/trace';
 import {TraceWriterConfig} from '../src/trace-writer';
 
 import {TestLogger} from './logger';
@@ -53,6 +54,13 @@ describe('Trace Writer', () => {
       // Don't run the risk of auto-flushing
       this.getConfig().bufferSize = Infinity;
       this.writeTrace(autoQueuedTrace);
+    }
+
+    writeTrace(trace: Trace) {
+      super.writeTrace(trace);
+      // Since flushBuffer doesn't call publish unless a trace is buffered,
+      // do that as well
+      this.buffer.push(JSON.stringify(trace));
     }
 
     protected publish(json: string) {

--- a/test/test-trace-writer.ts
+++ b/test/test-trace-writer.ts
@@ -328,7 +328,7 @@ describe('Trace Writer', () => {
           Object.assign({}, DEFAULT_CONFIG, {bufferSize: 1}), logger);
       writer.initialize(async err => {
         assert.ifError(err);
-        writer.writeSpan(createDummyTrace());
+        writer.writeTrace(createDummyTrace());
         // TraceWriter#publish should be called soon
         // (Promise task queue drain + immediate).
         await wait(200);
@@ -354,12 +354,12 @@ describe('Trace Writer', () => {
             Object.assign({}, DEFAULT_CONFIG, {bufferSize: NUM_SPANS}), logger);
         writer.initialize(async err => {
           assert.ifError(err);
-          writer.writeSpan(createDummyTrace());
+          writer.writeTrace(createDummyTrace());
           await wait(200);
           // Didn't publish yet
           assert.ok(!capturedRequestOptions);
           for (let i = 1; i < NUM_SPANS; i++) {
-            writer.writeSpan(createDummyTrace());
+            writer.writeTrace(createDummyTrace());
           }
           await wait(200);
           const publishedTraces: Trace[] =
@@ -377,7 +377,7 @@ describe('Trace Writer', () => {
           assert.ifError(err);
           // Two rounds to ensure that it's periodical
           for (let round = 0; round < 2; round++) {
-            writer.writeSpan(createDummyTrace());
+            writer.writeTrace(createDummyTrace());
             await wait(500);
             // Didn't publish yet
             assert.ok(!capturedRequestOptions);
@@ -397,7 +397,7 @@ describe('Trace Writer', () => {
           Object.assign({}, DEFAULT_CONFIG, {bufferSize: 1}), logger);
       writer.initialize(async err => {
         assert.ifError(err);
-        writer.writeSpan(createDummyTrace());
+        writer.writeTrace(createDummyTrace());
         await wait(200);
         assert.strictEqual(
             logger.getNumLogsWith('error', 'TraceWriter#publish'), 1);

--- a/test/test-trace-writer.ts
+++ b/test/test-trace-writer.ts
@@ -190,104 +190,90 @@ describe('Trace Writer', () => {
   });
 
   describe('initialization process', () => {
-    it('gets the project ID when none is passed in', (done) => {
+    it('gets the project ID when none is passed in', async () => {
       const writer = new TraceWriter(DEFAULT_CONFIG, logger);
       getProjectIdOverride = () => Promise.resolve('my-project');
-      writer.initialize(err => {
-        assert.ifError(err);
-        assert.strictEqual(writer.projectId, 'my-project');
-        writer.stop();
-        done();
-      });
+      await writer.initialize();
+      assert.strictEqual(writer.projectId, 'my-project');
+      writer.stop();
     });
 
-    it(`doesn't call Service#getProjectId if project ID is passed`, (done) => {
-      const writer = new TraceWriter(
-          Object.assign({projectId: 'my-project'}, DEFAULT_CONFIG), logger);
-      getProjectIdOverride = () => Promise.resolve('my-different-project');
-      writer.initialize(err => {
-        assert.ifError(err);
-        assert.strictEqual(writer.projectId, 'my-project');
-        writer.stop();
-        done();
-      });
-    });
+    it(`doesn't call Service#getProjectId if project ID is passed`,
+       async () => {
+         const writer = new TraceWriter(
+             Object.assign({projectId: 'my-project'}, DEFAULT_CONFIG), logger);
+         getProjectIdOverride = () => Promise.resolve('my-different-project');
+         await writer.initialize();
+         assert.strictEqual(writer.projectId, 'my-project');
+         writer.stop();
+       });
 
-    it(`errors when a project ID can't be determined`, (done) => {
+    it(`errors when a project ID can't be determined`, async () => {
       const writer = new TraceWriter(DEFAULT_CONFIG, logger);
       getProjectIdOverride = () => Promise.reject(new Error());
-      writer.initialize(err => {
-        assert.ok(err);
+      try {
+        await writer.initialize();
+      } catch (e) {
         // We can't know whether the metadata endpoints are called, so don't
         // check them.
         metadataScopes.cancel();
         writer.stop();
-        done();
-      });
+        return;
+      }
+      assert.fail('initialize should have thrown.');
     });
 
-    it('assigns default labels based on metadata', (done) => {
+    it('assigns default labels based on metadata', async () => {
       const writer = new TraceWriter(DEFAULT_CONFIG, logger);
       // Just for this scenario, use real metadata endpoints
       metadataScopes.cancel();
       nock.cleanAll();
       // Flakes suggest that nock.cleanAll works asynchronously, so continue
       // the test on a separate tick.
-      setImmediate(() => {
-        const gotInstanceId = instanceId(200, () => 'my-instance-id');
-        const gotHostname = hostname(200, () => 'my-hostname');
-        writer.initialize(err => {
-          assert.ifError(err);
-          assert.strictEqual(
-              writer.defaultLabels[TraceLabels.GCE_INSTANCE_ID],
-              'my-instance-id');
-          assert.strictEqual(
-              writer.defaultLabels[TraceLabels.GCE_HOSTNAME], 'my-hostname');
-          assert.strictEqual(
-              writer.defaultLabels[TraceLabels.GAE_MODULE_NAME], 'my-hostname');
-          gotInstanceId.done();
-          gotHostname.done();
-          writer.stop();
-          done();
-        });
-      });
+      await new Promise(res => setImmediate(res));
+      const gotInstanceId = instanceId(200, () => 'my-instance-id');
+      const gotHostname = hostname(200, () => 'my-hostname');
+      await writer.initialize();
+      assert.strictEqual(
+          writer.defaultLabels[TraceLabels.GCE_INSTANCE_ID], 'my-instance-id');
+      assert.strictEqual(
+          writer.defaultLabels[TraceLabels.GCE_HOSTNAME], 'my-hostname');
+      assert.strictEqual(
+          writer.defaultLabels[TraceLabels.GAE_MODULE_NAME], 'my-hostname');
+      gotInstanceId.done();
+      gotHostname.done();
+      writer.stop();
     });
 
-    it('assigns values for default labels in lieu of metadata', (done) => {
+    it('assigns values for default labels in lieu of metadata', async () => {
       const writer = new TraceWriter(DEFAULT_CONFIG, logger);
-      writer.initialize(err => {
-        assert.ifError(err);
-        assert.ok(!writer.defaultLabels[TraceLabels.GCE_INSTANCE_ID]);
-        assert.strictEqual(
-            writer.defaultLabels[TraceLabels.GCE_HOSTNAME], os.hostname());
-        assert.strictEqual(
-            writer.defaultLabels[TraceLabels.GAE_MODULE_NAME], os.hostname());
-        writer.stop();
-        done();
-      });
+      await writer.initialize();
+      assert.ok(!writer.defaultLabels[TraceLabels.GCE_INSTANCE_ID]);
+      assert.strictEqual(
+          writer.defaultLabels[TraceLabels.GCE_HOSTNAME], os.hostname());
+      assert.strictEqual(
+          writer.defaultLabels[TraceLabels.GAE_MODULE_NAME], os.hostname());
+      writer.stop();
     });
 
-    it('assigns other well-known labels', (done) => {
+    it('assigns other well-known labels', async () => {
       const writer = new TraceWriter(
           Object.assign({}, DEFAULT_CONFIG, {
             serviceContext:
                 {service: 'foo', version: 'bar', minorVersion: 'baz'}
           }),
           logger);
-      writer.initialize(err => {
-        assert.ifError(err);
-        assert.strictEqual(
-            writer.defaultLabels[TraceLabels.AGENT_DATA],
-            `node ${pjson.name} v${pjson.version}`);
-        assert.strictEqual(
-            writer.defaultLabels[TraceLabels.GAE_MODULE_NAME], 'foo');
-        assert.strictEqual(
-            writer.defaultLabels[TraceLabels.GAE_MODULE_VERSION], 'bar');
-        assert.strictEqual(
-            writer.defaultLabels[TraceLabels.GAE_VERSION], 'foo:bar.baz');
-        writer.stop();
-        done();
-      });
+      await writer.initialize();
+      assert.strictEqual(
+          writer.defaultLabels[TraceLabels.AGENT_DATA],
+          `node ${pjson.name} v${pjson.version}`);
+      assert.strictEqual(
+          writer.defaultLabels[TraceLabels.GAE_MODULE_NAME], 'foo');
+      assert.strictEqual(
+          writer.defaultLabels[TraceLabels.GAE_MODULE_VERSION], 'bar');
+      assert.strictEqual(
+          writer.defaultLabels[TraceLabels.GAE_VERSION], 'foo:bar.baz');
+      writer.stop();
     });
   });
 
@@ -323,87 +309,74 @@ describe('Trace Writer', () => {
       capturedRequestOptions = null;
     });
 
-    it('appends project ID and default labels to written traces', (done) => {
+    it('appends project ID and default labels to written traces', async () => {
       const writer = new MockedRequestTraceWriter(
           Object.assign({}, DEFAULT_CONFIG, {bufferSize: 1}), logger);
-      writer.initialize(async err => {
-        assert.ifError(err);
-        writer.writeTrace(createDummyTrace());
-        // TraceWriter#publish should be called soon
-        // (Promise task queue drain + immediate).
-        await wait(200);
-        const publishedTraces: Trace[] =
-            JSON.parse(capturedRequestOptions!.body).traces;
-        assert.strictEqual(publishedTraces.length, 1);
-        assert.strictEqual(publishedTraces[0].projectId, '0');
-        assert.ok(publishedTraces[0].spans[0].endTime);
-        Object.keys(writer.defaultLabels).forEach(key => {
-          assert.strictEqual(
-              publishedTraces[0].spans[0].labels[key],
-              writer.defaultLabels[key]);
-        });
-        writer.stop();
-        done();
+      await writer.initialize();
+      writer.writeTrace(createDummyTrace());
+      // TraceWriter#publish should be called soon
+      // (Promise task queue drain + immediate).
+      await wait(200);
+      const publishedTraces: Trace[] =
+          JSON.parse(capturedRequestOptions!.body).traces;
+      assert.strictEqual(publishedTraces.length, 1);
+      assert.strictEqual(publishedTraces[0].projectId, '0');
+      assert.ok(publishedTraces[0].spans[0].endTime);
+      Object.keys(writer.defaultLabels).forEach(key => {
+        assert.strictEqual(
+            publishedTraces[0].spans[0].labels[key], writer.defaultLabels[key]);
       });
+      writer.stop();
     });
 
     describe('condition for publishing traces', () => {
-      it('is satisfied when the buffer is full', (done) => {
+      it('is satisfied when the buffer is full', async () => {
         const NUM_SPANS = 5;
         const writer = new MockedRequestTraceWriter(
             Object.assign({}, DEFAULT_CONFIG, {bufferSize: NUM_SPANS}), logger);
-        writer.initialize(async err => {
-          assert.ifError(err);
+        await writer.initialize();
+        writer.writeTrace(createDummyTrace());
+        await wait(200);
+        // Didn't publish yet
+        assert.ok(!capturedRequestOptions);
+        for (let i = 1; i < NUM_SPANS; i++) {
           writer.writeTrace(createDummyTrace());
-          await wait(200);
-          // Didn't publish yet
-          assert.ok(!capturedRequestOptions);
-          for (let i = 1; i < NUM_SPANS; i++) {
-            writer.writeTrace(createDummyTrace());
-          }
-          await wait(200);
-          const publishedTraces: Trace[] =
-              JSON.parse(capturedRequestOptions!.body).traces;
-          assert.strictEqual(publishedTraces.length, NUM_SPANS);
-          writer.stop();
-          done();
-        });
+        }
+        await wait(200);
+        const publishedTraces: Trace[] =
+            JSON.parse(capturedRequestOptions!.body).traces;
+        assert.strictEqual(publishedTraces.length, NUM_SPANS);
+        writer.stop();
       });
 
-      it('is satisfied periodically', (done) => {
+      it('is satisfied periodically', async () => {
         const writer = new MockedRequestTraceWriter(
             Object.assign({}, DEFAULT_CONFIG, {flushDelaySeconds: 1}), logger);
-        writer.initialize(async err => {
-          assert.ifError(err);
-          // Two rounds to ensure that it's periodical
-          for (let round = 0; round < 2; round++) {
-            writer.writeTrace(createDummyTrace());
-            await wait(500);
-            // Didn't publish yet
-            assert.ok(!capturedRequestOptions);
-            await wait(600);
-            assert.ok(capturedRequestOptions);
-            capturedRequestOptions = null;
-          }
-          writer.stop();
-          done();
-        });
+        await writer.initialize();
+        // Two rounds to ensure that it's periodical
+        for (let round = 0; round < 2; round++) {
+          writer.writeTrace(createDummyTrace());
+          await wait(500);
+          // Didn't publish yet
+          assert.ok(!capturedRequestOptions);
+          await wait(600);
+          assert.ok(capturedRequestOptions);
+          capturedRequestOptions = null;
+        }
+        writer.stop();
       });
     });
 
-    it('emits an error if there was an error publishing', (done) => {
+    it('emits an error if there was an error publishing', async () => {
       overrideRequestResponse = () => Promise.reject(new Error());
       const writer = new MockedRequestTraceWriter(
           Object.assign({}, DEFAULT_CONFIG, {bufferSize: 1}), logger);
-      writer.initialize(async err => {
-        assert.ifError(err);
-        writer.writeTrace(createDummyTrace());
-        await wait(200);
-        assert.strictEqual(
-            logger.getNumLogsWith('error', 'TraceWriter#publish'), 1);
-        writer.stop();
-        done();
-      });
+      await writer.initialize();
+      writer.writeTrace(createDummyTrace());
+      await wait(200);
+      assert.strictEqual(
+          logger.getNumLogsWith('error', 'TraceWriter#publish'), 1);
+      writer.stop();
     });
   });
 });

--- a/test/trace.ts
+++ b/test/trace.ts
@@ -69,7 +69,7 @@ export class TestTraceWriter extends TraceWriter {
   initialize(cb: (err?: Error) => void): void {
     cb();
   }
-  writeSpan(trace: Trace): void {
+  writeTrace(trace: Trace): void {
     traces.push(trace);
     trace.spans.forEach(span => {
       spans.push(span);

--- a/test/trace.ts
+++ b/test/trace.ts
@@ -66,9 +66,8 @@ export class TestTraceWriter extends TraceWriter {
     this.getConfig().projectId = '0';
   }
 
-  initialize(cb: (err?: Error) => void): void {
-    cb();
-  }
+  async initialize(): Promise<void> {}
+
   writeTrace(trace: Trace): void {
     traces.push(trace);
     trace.spans.forEach(span => {


### PR DESCRIPTION
This PR contains three changes (in separate commits) that improve the TraceWriter API, narrowing down its trace-writing surface to _just_ `writeTraces` and promisifying the initialization step. This should make #794 easier to fix.