### PR TITLE
fix: avoid memory leaks due to undisposed promise resources

### DIFF
--- a/src/cls/async-hooks.ts
+++ b/src/cls/async-hooks.ts
@@ -59,7 +59,8 @@ export class AsyncHooksCLS<Context extends {}> implements CLS<Context> {
         // init is called when a new AsyncResource is created. We want code
         // that runs within the scope of this new AsyncResource to see the same
         // context as its "parent" AsyncResource. The criteria for the parent
-        // depends on the type of the AsyncResource.
+        // depends on the type of the AsyncResource. (If the parent doesn't have
+        // an associated context, don't do anything.)
         if (type === 'PROMISE' && this.contexts[currentId] !== undefined) {
           // Opt not to use the trigger ID for Promises, as this causes context
           // confusion in applications using async/await.
@@ -79,9 +80,7 @@ export class AsyncHooksCLS<Context extends {}> implements CLS<Context> {
           this.contexts[id] = this.contexts[triggerId];
         }
         // Note that this function only assigns values in this.contexts to
-        // values under other keys; it never generates new context values, and
-        // doesn't add an additional entry to this.contexts if there is no
-        // current, explicitly set context.
+        // values under other keys; it never generates new context values.
         // Consumers of the CLS API will get the sentinel (default) value if
         // they query the current context when it is not stored in
         // this.contexts.

--- a/src/cls/async-hooks.ts
+++ b/src/cls/async-hooks.ts
@@ -55,16 +55,17 @@ export class AsyncHooksCLS<Context extends {}> implements CLS<Context> {
     // Create the hook.
     this.hook = this.ah.createHook({
       init: (id: number, type: string, triggerId: number, resource: {}) => {
+        const currentId = this.ah.executionAsyncId();
         // init is called when a new AsyncResource is created. We want code
         // that runs within the scope of this new AsyncResource to see the same
         // context as its "parent" AsyncResource. The criteria for the parent
         // depends on the type of the AsyncResource.
-        if (type === 'PROMISE') {
+        if (type === 'PROMISE' && this.contexts[currentId] !== undefined) {
           // Opt not to use the trigger ID for Promises, as this causes context
           // confusion in applications using async/await.
           // Instead, use the ID of the AsyncResource in whose scope we are
           // currently running.
-          this.contexts[id] = this.contexts[this.ah.executionAsyncId()];
+          this.contexts[id] = this.contexts[currentId];
         } else if (this.contexts[triggerId] !== undefined) {
           // Use the trigger ID for any other type. In Node core, this is
           // usually equal the ID of the AsyncResource in whose scope we are
@@ -77,10 +78,13 @@ export class AsyncHooksCLS<Context extends {}> implements CLS<Context> {
           // selection.
           this.contexts[id] = this.contexts[triggerId];
         }
-        // Note that this function always assigns values in this.contexts to
-        // values under other keys, which may or may not be undefined. Consumers
-        // of the CLS API will get the sentinel (default) value if they query
-        // the current context when it is stored as undefined.
+        // Note that this function only assigns values in this.contexts to
+        // values under other keys; it never generates new context values, and
+        // doesn't add an additional entry to this.contexts if there is no
+        // current, explicitly set context.
+        // Consumers of the CLS API will get the sentinel (default) value if
+        // they query the current context when it is not stored in
+        // this.contexts.
       },
       destroy: (id: number) => {
         // destroy is called when the AsyncResource is no longer used, so also

--- a/src/cls/async-hooks.ts
+++ b/src/cls/async-hooks.ts
@@ -91,11 +91,11 @@ export class AsyncHooksCLS<Context extends {}> implements CLS<Context> {
         delete this.contexts[id];
       },
       promiseResolve: (id: number) => {
-        // Some Promise async resources do not get destroyed with a destroy
-        // hook, but a promiseResolve event is emitted instead. If this event
-        // is emitted, the async scope of the Promise will not be entered again,
-        // so it is generally safe to delete its entry in the map. (There is a
-        // possibility that a future async resource will directly reference
+        // Promise async resources may not get their destroy hook entered for
+        // a long time, so we listen on promiseResolve hooks as well. If this
+        // event is emitted, the async scope of the Promise will not be entered
+        // again, so it is generally safe to delete its entry in the map. (There
+        // is a possibility that a future async resource will directly reference
         // this Promise as its trigger parent -- in this case, it will have
         // the wrong parent, but this is still better than a potential memory
         // leak.)

--- a/test/test-cls-ah.ts
+++ b/test/test-cls-ah.ts
@@ -177,12 +177,11 @@ maybeSkip(describe)('AsyncHooks-based CLS', () => {
           },
           {
             description: 'an async function with spread args',
-            // TODO(kjin): A bug in exists in earlier versions of Node that
-            // causes promiseResolve to not be called when an async function
-            // with spread args is invoked. This is fixed in Node 11; identify
-            // and backport the fix to earlier versions of Node and remove the
-            // version predicate.
-            skip: semver.satisfies(process.version, '<11'),
+            // TODO(kjin): A possible bug in exists that causes an extra Promise
+            // async resource to be initialized when an async function with
+            // spread args is invoked. promiseResolve is not called for this
+            // async resource. Fix this bug and then remove this skip directive.
+            skip: true,
             fn: async (...args: number[]) => args
           }
         ];


### PR DESCRIPTION
Most Promise async resources require a separate `promiseResolve` event listener. See the inline comments for more details.