### PR TITLE
refactor: address trace policy TODOs

### DIFF
--- a/test/plugins/common.ts
+++ b/test/plugins/common.ts
@@ -19,7 +19,6 @@ import '../override-gcp-metadata';
 import { cls, TraceCLS } from '../../src/cls';
 import { StackdriverTracer } from '../../src/trace-api';
 import { traceWriter } from '../../src/trace-writer';
-import * as TracingPolicy from '../../src/tracing-policy';
 import { SpanType } from '../../src/constants';
 import { TestLogger } from '../logger';
 
@@ -70,10 +69,10 @@ shimmer.wrap(trace, 'start', function(original) {
       ignoreContextHeader: false,
       rootSpanNameOverride: (name: string) => name,
       samplingRate: 0,
+      ignoreUrls: [],
       spansPerTraceSoftLimit: Infinity,
       spansPerTraceHardLimit: Infinity
     }, new TestLogger());
-    testTraceAgent.policy = new TracingPolicy.TraceAllPolicy();
     return result;
   };
 });

--- a/test/plugins/test-trace-grpc.ts
+++ b/test/plugins/test-trace-grpc.ts
@@ -282,15 +282,10 @@ Object.keys(versions).forEach(function(version) {
 
     before(function() {
       // Set up to record invocations of shouldTrace
-      shimmer.wrap(TracingPolicy, 'createTracePolicy', function(original) {
-        return function() {
-          var result = original.apply(this, arguments);
-          var shouldTrace = result.shouldTrace;
-          result.shouldTrace = function() {
-            shouldTraceArgs.push(Array.prototype.slice.call(arguments, 0));
-            return shouldTrace.apply(this, arguments);
-          };
-          return result;
+      shimmer.wrap(TracingPolicy.TracePolicy.prototype, 'shouldTrace', function(original) {
+        return function(options) {
+          shouldTraceArgs.push(options);
+          return original.apply(this, arguments);
         };
       });
 
@@ -471,10 +466,10 @@ Object.keys(versions).forEach(function(version) {
         var prefix = 'grpc:/nodetest.Tester/Test';
         // calls to shouldTrace should be in the order which the client method
         // of each type was called.
-        assert.strictEqual(shouldTraceArgs[3][1], prefix + 'Unary');
-        assert.strictEqual(shouldTraceArgs[2][1], prefix + 'ClientStream');
-        assert.strictEqual(shouldTraceArgs[1][1], prefix + 'ServerStream');
-        assert.strictEqual(shouldTraceArgs[0][1], prefix + 'BidiStream');
+        assert.strictEqual(shouldTraceArgs[3].url, prefix + 'Unary');
+        assert.strictEqual(shouldTraceArgs[2].url, prefix + 'ClientStream');
+        assert.strictEqual(shouldTraceArgs[1].url, prefix + 'ServerStream');
+        assert.strictEqual(shouldTraceArgs[0].url, prefix + 'BidiStream');
         done();
       };
       next = callUnary.bind(null, client, grpc, {}, next);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
     "test/test-trace-api.ts",
     "test/test-trace-api-none-cls.ts",
     "test/test-trace-cluster.ts",
+    "test/test-trace-policy.ts",
     "test/test-trace-uncaught-exception.ts",
     "test/test-trace-web-frameworks.ts",
     "test/test-trace-writer.ts",


### PR DESCRIPTION
This change removes two TODOs from the codebase related the Trace Policy, namely:
- Turn `TracePolicy` into a class
- Privatize `StackdriverTracer.policy`