### PR TITLE
test: remove cluster test todo

### DIFF
--- a/test/test-trace-cluster.ts
+++ b/test/test-trace-cluster.ts
@@ -63,16 +63,12 @@ describe('test-trace-cluster', () => {
       });
       const port = (server.address() as AddressInfo).port;
 
-      // TODO(kjin): This fails because context is incorrectly propagated to
-      // the request handler. See issue #659
-
-      // await trace.get().runInRootSpan({ name: 'outer' }, async span => {
-      //   assert.ok(span);
-      //   await axios.get(`http://localhost:${port}`);
-      //   span!.endSpan();
-      // });
       let recordedTime = Date.now();
-      await axios.get(`http://localhost:${port}`);
+      await testTraceModule.get().runInRootSpan({name: 'outer'}, async span => {
+        assert.ok(span);
+        await axios.get(`http://localhost:${port}`);
+        span!.endSpan();
+      });
       recordedTime = Date.now() - recordedTime;
       const serverSpan = testTraceModule.getOneSpan(isServerSpan);
       assertSpanDuration(serverSpan, [DEFAULT_SPAN_DURATION, recordedTime]);


### PR DESCRIPTION
Fixes #659

When the TODO in question was written (see diff), there was a failure that was attributed to how `cluster` interacted with `async_hooks`. After doing some investigation, I realized that the fault actually lies in [the way CLS was being implemented on top of `async_hooks` at the time](https://github.com/googleapis/cloud-trace-nodejs/blob/v2.8.0/src/cls/async-hooks.ts#L47-L59). Because the `after` hook isn't being called, context would leak to the next entered resource if the next entered resource didn't already have a context associated with it.

This has already been fixed in v2.9.0, specifically #734, which obviated `before`/`after` hooks entirely. So this test should work as it did before.