### PR TITLE
fix: make no option flags behave the same as o=1

### DIFF
--- a/src/trace-api.ts
+++ b/src/trace-api.ts
@@ -180,6 +180,10 @@ export class StackdriverTracer implements Tracer {
       parsedContext = util.parseContextFromHeader(options.traceContext);
     }
     if (parsedContext) {
+      if (parsedContext.options === undefined) {
+        // If there are no incoming option flags, default to 0x1.
+        parsedContext.options = 1;
+      }
       Object.assign(incomingTraceContext, parsedContext);
     } else if (
         this.config!.contextHeaderBehavior ===

--- a/test/test-trace-api.ts
+++ b/test/test-trace-api.ts
@@ -275,6 +275,17 @@ describe('Trace Interface', () => {
           testTraceModule.getSpans(span => span.name === 'root3').length, 0);
     });
 
+    it('should trace if no option flags are provided', () => {
+      createTraceAgent({enhancedDatabaseReporting: false})
+          .runInRootSpan(
+              {name: 'root', traceContext: '123456/667'}, (rootSpan) => {
+                rootSpan.endSpan();
+              });
+      const foundTrace =
+          testTraceModule.getOneTrace(trace => trace.traceId === '123456');
+      assert.strictEqual(foundTrace.spans.length, 1);
+    });
+
     describe('getting response trace context', () => {
       it('should behave as expected', () => {
         const fakeTraceId = 'ffeeddccbbaa99887766554433221100';


### PR DESCRIPTION
This fixes a regression in 3.3.0 that causes tracing to not work in GAE, because GAE doesn't specify options flags.