### PR TITLE
chore: add a sample app

### DIFF
--- a/samples/.gitignore
+++ b/samples/.gitignore
@@ -1,0 +1,1 @@
+.gcloudignore

--- a/samples/README.md
+++ b/samples/README.md
@@ -2,9 +2,12 @@
 
 This sample demonstrates using [Stackdriver Trace][trace] with Node.js.
 
+> Node 8+ is required for this sample.
+
 * [Setup](#setup)
 * [Running locally](#running-locally)
 * [Deploying to App Engine](#deploying-to-app-engine)
+* [Viewing Traces](#viewing-traces)
 
 ## Setup
 
@@ -14,33 +17,19 @@ Before you can run or deploy the sample, you need to do the following:
     running and deploying.
 1.  Install dependencies:
 
-    With `npm`:
-
         npm install
-
-    or with `yarn`:
-
-        yarn install
 
 ## Running locally
 
-With `npm`:
-
     npm start
-
-or with `yarn`:
-
-    yarn start
 
 ## Deploying to App Engine
 
-With `npm`:
+Ensure that you have an up-to-date `gcloud` (run `gcloud components update`), and then:
 
     npm run deploy
 
-or with `yarn`:
-
-    yarn run deploy
+## Viewing Traces
 
 Use the [Stackdriver Trace dashboard](https://console.cloud.google.com/traces/traces) to inspect recorded traces.
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,48 @@
+# Stackdriver Trace for Node.js Sample Application
+
+This sample demonstrates using [Stackdriver Trace][trace] with Node.js.
+
+* [Setup](#setup)
+* [Running locally](#running-locally)
+* [Deploying to App Engine](#deploying-to-app-engine)
+
+## Setup
+
+Before you can run or deploy the sample, you need to do the following:
+
+1.  Refer to the [this README file][readme] for instructions on
+    running and deploying.
+1.  Install dependencies:
+
+    With `npm`:
+
+        npm install
+
+    or with `yarn`:
+
+        yarn install
+
+## Running locally
+
+With `npm`:
+
+    npm start
+
+or with `yarn`:
+
+    yarn start
+
+## Deploying to App Engine
+
+With `npm`:
+
+    npm run deploy
+
+or with `yarn`:
+
+    yarn run deploy
+
+Use the [Stackdriver Trace dashboard](https://console.cloud.google.com/traces/traces) to inspect recorded traces.
+
+[trace]: https://cloud.google.com/trace/
+[readme]: https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/master/appengine/README.md

--- a/samples/app.js
+++ b/samples/app.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2017, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// [START trace_app]
+if (process.env.NODE_ENV === 'production') {
+  // [START trace_setup_implicit]
+  require('@google-cloud/trace-agent').start();
+  // [END trace_setup_implicit]
+}
+
+const express = require('express');
+const got = require('got');
+
+const app = express();
+const DISCOVERY_URL = 'https://www.googleapis.com/discovery/v1/apis';
+
+// This incoming HTTP request should be captured by Trace
+app.get('/', (req, res) => {
+  // This outgoing HTTP request should be captured by Trace
+  got(DISCOVERY_URL, { json: true })
+    .then((response) => {
+      const names = response.body.items.map((item) => item.name);
+
+      res
+        .status(200)
+        .send(names.join('\n'))
+        .end();
+    })
+    .catch((err) => {
+      console.error(err);
+      res
+        .status(500)
+        .end();
+    });
+});
+
+// Start the server
+const PORT = process.env.PORT || 8080;
+app.listen(PORT, () => {
+  console.log(`App listening on port ${PORT}`);
+  console.log('Press Ctrl+C to quit.');
+});
+// [END trace_app]

--- a/samples/app.yaml
+++ b/samples/app.yaml
@@ -1,0 +1,17 @@
+# Copyright 2016, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START app_yaml]
+runtime: nodejs
+env: flex
+# [END app_yaml]

--- a/samples/app.yaml
+++ b/samples/app.yaml
@@ -12,6 +12,5 @@
 # limitations under the License.
 
 # [START app_yaml]
-runtime: nodejs
-env: flex
+runtime: nodejs10
 # [END app_yaml]

--- a/samples/package.json
+++ b/samples/package.json
@@ -1,41 +1,24 @@
 {
-  "name": "nodejs-docs-samples-trace",
-  "description": "Sample for Google Stackdriver Trace on Google App Engine Flexible Environment.",
-  "version": "0.0.1",
+  "name": "cloud-trace-nodejs-samples",
+  "description": "Sample for Google Stackdriver Trace on Google App Engine Standard Environment.",
+  "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
+    "url": "https://github.com/googleapis/cloud-trace-nodejs.git"
   },
   "engines": {
-    "node": ">=4.3.2"
+    "node": ">=8"
   },
   "scripts": {
     "deploy": "gcloud app deploy",
-    "start": "node app.js",
-    "lint": "repo-tools lint",
-    "pretest": "npm run lint",
-    "test": "repo-tools test app",
-    "e2e-test": "repo-tools test deploy"
+    "start": "node app.js"
   },
   "dependencies": {
-    "@google-cloud/trace-agent": "3.3.1",
-    "express": "4.16.2",
-    "got": "8.2.0"
-  },
-  "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "2.2.1",
-    "semistandard": "^12.0.1"
-  },
-  "cloud-repo-tools": {
-    "test": {
-      "app": {
-        "msg": "acceleratedmobilepageurl"
-      }
-    },
-    "requiresKeyFile": true,
-    "requiresProjectId": true
+    "@google-cloud/trace-agent": "^3.3.1",
+    "express": "^4.16.4",
+    "got": "^9.3.2"
   }
 }

--- a/samples/package.json
+++ b/samples/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "nodejs-docs-samples-trace",
+  "description": "Sample for Google Stackdriver Trace on Google App Engine Flexible Environment.",
+  "version": "0.0.1",
+  "private": true,
+  "license": "Apache-2.0",
+  "author": "Google Inc.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
+  },
+  "engines": {
+    "node": ">=4.3.2"
+  },
+  "scripts": {
+    "deploy": "gcloud app deploy",
+    "start": "node app.js",
+    "lint": "repo-tools lint",
+    "pretest": "npm run lint",
+    "test": "repo-tools test app",
+    "e2e-test": "repo-tools test deploy"
+  },
+  "dependencies": {
+    "@google-cloud/trace-agent": "3.3.1",
+    "express": "4.16.2",
+    "got": "8.2.0"
+  },
+  "devDependencies": {
+    "@google-cloud/nodejs-repo-tools": "2.2.1",
+    "semistandard": "^12.0.1"
+  },
+  "cloud-repo-tools": {
+    "test": {
+      "app": {
+        "msg": "acceleratedmobilepageurl"
+      }
+    },
+    "requiresKeyFile": true,
+    "requiresProjectId": true
+  }
+}

--- a/samples/snippets.js
+++ b/samples/snippets.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2017, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// [START trace_setup_explicit]
+require('@google-cloud/trace-agent').start({
+  projectId: 'your-project-id',
+  keyFilename: '/path/to/key.json'
+});
+// [END trace_setup_explicit]


### PR DESCRIPTION
Fixes #909

This sample app was taken directly from https://github.com/GoogleCloudPlatform/nodejs-docs-samples/tree/master/trace. I modified the README (to fix broken links, and also to remove sections that seemed copy-pasted from other READMEs) and package.json (to update the Trace Agent version).