### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,5 +15,6 @@
       "extends": "packages:linters",
       "groupName": "linters"
     }
-  ]
+  ],
+  "ignoreDeps": ["@types/protobufjs"]
 }


### PR DESCRIPTION
`@types/protobufjs` is necessary since `protobufjs` only introduced types in v6, and we are "pinned" to v5.

This PR should fix #935.