### PR TITLE
chore: 3.5.0 release proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/trace-agent",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Node.js Support for StackDriver Trace",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",


### PR DESCRIPTION
[Release Notes](https://github.com/googleapis/cloud-trace-nodejs/releases/tag/untagged-5e56392ca8cc1c15034a)