### PR TITLE
feat: allow users to specify a propagation mechanism

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
   },
   "dependencies": {
     "@google-cloud/common": "^0.32.1",
+    "@opencensus/propagation-stackdriver": "0.0.11",
     "builtin-modules": "^3.0.0",
     "console-log-level": "^1.4.0",
     "continuation-local-storage": "^3.2.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -102,12 +102,21 @@ export interface Config {
    * A list of trace plugins to load. Each field's key in this object is the
    * name of the module to trace, and its value is the require-friendly path
    * to the plugin. (See the default configuration below for examples.)
-   * Any user-provided value will be used to extend its default value.
-   * To disable a plugin in this list, you may override its path with a falsy
-   * value. Disabling any of the default plugins may cause unwanted behavior,
-   * so use caution.
+   * Any user-provided value for this field will be used to extend its default
+   * value. To disable a plugin in this list, you may override its path with a
+   * falsy value. Disabling any of the default plugins may cause unwanted
+   * behavior, so use caution.
    */
   plugins?: {[pluginName: string]: string;};
+
+  /**
+   * A require-friendly path to an OpenCensus-compatible propagation module to
+   * support context propagation across services with HTTP headers, or a list of
+   * such paths. Any user-provided value will replace the default value. To
+   * disable propagation completely, pass an empty string or empty array for
+   * this field.
+   */
+  propagation?: string|string[];
 
   /**
    * The max number of frames to include on traces; pass a value of 0 to
@@ -272,6 +281,7 @@ export const defaultConfig = {
     'redis': path.join(pluginDirectory, 'plugin-redis.js'),
     'restify': path.join(pluginDirectory, 'plugin-restify.js')
   },
+  propagation: '@opencensus/propagation-stackdriver',
   stackTraceLimit: 10,
   flushDelaySeconds: 30,
   ignoreUrls: ['/_ah/health'],

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@
  */
 
 import * as path from 'path';
+import {Propagation} from './plugin-types';
 
 const pluginDirectory =
     path.join(path.resolve(__dirname, '..'), 'src', 'plugins');
@@ -110,13 +111,12 @@ export interface Config {
   plugins?: {[pluginName: string]: string;};
 
   /**
-   * A require-friendly path to an OpenCensus-compatible propagation module to
-   * support context propagation across services with HTTP headers, or a list of
-   * such paths. Any user-provided value will replace the default value. To
-   * disable propagation completely, pass an empty string or empty array for
-   * this field.
+   * Either a require-friendly path to an OpenCensus-compatible propagation
+   * module to support context propagation across services with HTTP headers or
+   * the module itself, or a list of such paths or modules. Any user-provided
+   * value will replace the default value.
    */
-  propagation?: string|string[];
+  propagation?: string|Propagation|Array<string|Propagation>;
 
   /**
    * The max number of frames to include on traces; pass a value of 0 to

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,13 @@ function initConfig(projectConfig: Forceable<Config>):
     config.clsMechanism = ahAvailable ? 'async-hooks' : 'async-listener';
   }
 
+  // Canonicalize the user-specified propagation mechanism.
+  if (!config.propagation) {
+    config.propagation = [];
+  } else if (typeof config.propagation === 'string') {
+    config.propagation = [config.propagation];
+  }
+
   return config;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ function initConfig(projectConfig: Forceable<Config>):
   // Canonicalize the user-specified propagation mechanism.
   if (!config.propagation) {
     config.propagation = [];
-  } else if (typeof config.propagation === 'string') {
+  } else if (!Array.isArray(config.propagation)) {
     config.propagation = [config.propagation];
   }
 

--- a/src/plugin-types.ts
+++ b/src/plugin-types.ts
@@ -40,9 +40,16 @@ export interface Span {
   /**
    * Gets the current trace context serialized as a string, or an empty string
    * if it can't be generated.
+   * TODO(kjin): Deprecate/remove this method.
    * @return The stringified trace context.
    */
   getTraceContext(): string;
+
+  /**
+   * Gets the current trace context, or null if it can't be retrieved.
+   * @return The trace context.
+   */
+  getContext(): TraceContext|null;
 
   /**
    * Adds a key-value pair as a label to the trace span. The value will be
@@ -106,10 +113,9 @@ export interface RootSpanOptions extends SpanOptions {
   /* A Method associated with the root span, if applicable. */
   method?: string;
   /**
-   * The serialized form of an object that contains information about an
-   * existing trace context, if it exists.
+   * An existing trace context, if it exists.
    */
-  traceContext?: string|null;
+  traceContext?: TraceContext|string|null;
 }
 
 export interface Tracer {
@@ -196,9 +202,10 @@ export interface Tracer {
    * based on the trace context header value in the corresponding incoming
    * request, as well as the result from the local trace policy on whether this
    * request will be traced or not.
+   * TODO(kjin): Deprecate/remove this method.
    * @param incomingTraceContext The trace context that was attached to
    * the incoming web request, or null if the incoming request didn't have one.
-   * @param isTraced Whether the incoming was traced. This is determined
+   * @param isTraced Whether the incoming request was traced. This is determined
    * by the local tracing policy.
    * @returns If the response should contain the trace context within its
    * header, the string to be set as this header's value. Otherwise, an empty
@@ -206,6 +213,24 @@ export interface Tracer {
    */
   getResponseTraceContext(incomingTraceContext: string|null, isTraced: boolean):
       string;
+
+  /**
+   * Generates a trace context object that should be set as the trace
+   * context header in a response to an incoming web request. This value is
+   * based on the trace context header value in the corresponding incoming
+   * request, as well as the result from the local trace policy on whether this
+   * request will be traced or not.
+   * @param incomingTraceContext The trace context that was attached to
+   * the incoming web request, or null if the incoming request didn't have one.
+   * @param isTraced Whether the incoming request was traced. This is determined
+   * by the local tracing policy.
+   * @returns If the response should contain the trace context within its
+   * header, the context object to be serialized as this header's value.
+   * Otherwise, null.
+   */
+  getResponseContext(
+      incomingTraceContext: TraceContext|null, isTraced: boolean): TraceContext
+      |null;
 
   /**
    * Binds the trace context to the given function.
@@ -233,11 +258,25 @@ export interface Tracer {
   readonly spanTypes: typeof SpanType;
   /** A collection of functions for encoding and decoding trace context. */
   readonly traceContextUtils: {
+    // TODO(kjin): Deprecate/remove this method.
     encodeAsString: (ctx: TraceContext) => string;
+    // TODO(kjin): Deprecate/remove this method.
     decodeFromString: (str: string) => TraceContext | null;
     encodeAsByteArray: (ctx: TraceContext) => Buffer;
     decodeFromByteArray: (buf: Buffer) => TraceContext | null;
   };
+  /**
+   * A collection of functions for dealing with trace context in HTTP headers.
+   */
+  readonly propagation: Propagation;
+}
+
+export type GetHeaderFunction = (key: string) => string[]|string|null;
+export type SetHeaderFunction = (key: string, value: string) => void;
+export interface Propagation {
+  extract: (getHeader: GetHeaderFunction) => TraceContext | null;
+  inject:
+      (setHeader: SetHeaderFunction, traceContext: TraceContext|null) => void;
 }
 
 export interface Monkeypatch<T> {

--- a/src/plugins/plugin-connect.ts
+++ b/src/plugins/plugin-connect.ts
@@ -28,14 +28,6 @@ type Request = IncomingMessage&{originalUrl?: string};
 
 const SUPPORTED_VERSIONS = '3.x';
 
-function getFirstHeader(req: IncomingMessage, key: string): string|null {
-  let headerValue = req.headers[key] || null;
-  if (headerValue && typeof headerValue !== 'string') {
-    headerValue = headerValue[0];
-  }
-  return headerValue;
-}
-
 function createMiddleware(api: PluginTypes.Tracer):
     connect_3.NextHandleFunction {
   return function middleware(req: Request, res, next) {
@@ -43,17 +35,16 @@ function createMiddleware(api: PluginTypes.Tracer):
       name: req.originalUrl ? (urlParse(req.originalUrl).pathname || '') : '',
       url: req.originalUrl,
       method: req.method,
-      traceContext:
-          getFirstHeader(req, api.constants.TRACE_CONTEXT_HEADER_NAME),
+      traceContext: api.propagation.extract((key) => req.headers[key] || null),
       skipFrames: 1
     };
     api.runInRootSpan(options, (root) => {
       // Set response trace context.
-      const responseTraceContext = api.getResponseTraceContext(
-          options.traceContext || null, api.isRealSpan(root));
+      const responseTraceContext =
+          api.getResponseContext(options.traceContext, api.isRealSpan(root));
       if (responseTraceContext) {
-        res.setHeader(
-            api.constants.TRACE_CONTEXT_HEADER_NAME, responseTraceContext);
+        api.propagation.inject(
+            (k, v) => res.setHeader(k, v), responseTraceContext);
       }
 
       if (!api.isRealSpan(root)) {

--- a/src/plugins/plugin-http.ts
+++ b/src/plugins/plugin-http.ts
@@ -142,9 +142,11 @@ function makeRequestTrace(
       // headers.
       options = Object.assign({}, options) as ClientRequestArgs;
       options.headers = Object.assign({}, options.headers);
+      const headers = options.headers;
       // Inject the trace context header.
-      options.headers[api.constants.TRACE_CONTEXT_HEADER_NAME] =
-          span.getTraceContext();
+      api.propagation.inject((key, value) => {
+        headers[key] = value;
+      }, span.getContext());
     }
 
     const req = request(options, (res) => {
@@ -188,19 +190,20 @@ function makeRequestTrace(
     // Inject the trace context header, but only if it wasn't already injected
     // earlier.
     if (!traceHeaderPreinjected) {
-      try {
-        req.setHeader(
-            api.constants.TRACE_CONTEXT_HEADER_NAME, span.getTraceContext());
-      } catch (e) {
-        if (e.code === ERR_HTTP_HEADERS_SENT ||
-            e.message === ERR_HTTP_HEADERS_SENT_MSG) {
-          // Swallow the error.
-          // This would happen in the pathological case where the Expect header
-          // exists but is not detected by hasExpectHeader.
-        } else {
-          throw e;
+      api.propagation.inject((key, value) => {
+        try {
+          req.setHeader(key, value);
+        } catch (e) {
+          if (e.code === ERR_HTTP_HEADERS_SENT ||
+              e.message === ERR_HTTP_HEADERS_SENT_MSG) {
+            // Swallow the error.
+            // This would happen in the pathological case where the Expect header
+            // exists but is not detected by hasExpectHeader.
+          } else {
+            throw e;
+          }
         }
-      }
+      }, span.getContext());
     }
     return req;
   };

--- a/src/plugins/plugin-http2.ts
+++ b/src/plugins/plugin-http2.ts
@@ -97,8 +97,8 @@ function makeRequestTrace(
         api.labels.HTTP_METHOD_LABEL_KEY, extractMethodName(newHeaders));
     requestLifecycleSpan.addLabel(
         api.labels.HTTP_URL_LABEL_KEY, extractUrl(authority, newHeaders));
-    newHeaders[api.constants.TRACE_CONTEXT_HEADER_NAME] =
-        requestLifecycleSpan.getTraceContext();
+    api.propagation.inject(
+        (k, v) => newHeaders[k] = v, requestLifecycleSpan.getContext());
     const stream: http2.ClientHttp2Stream = request.call(
         this, newHeaders, ...Array.prototype.slice.call(arguments, 1));
     api.wrapEmitter(stream);

--- a/src/plugins/plugin-koa.ts
+++ b/src/plugins/plugin-koa.ts
@@ -40,14 +40,6 @@ type CreateMiddlewareFn<T> = (api: PluginTypes.Tracer) => T;
 // propagateContext flag. The type of "next" differs between Koa 1 and 2.
 type GetNextFn<T> = (propagateContext: boolean) => T;
 
-function getFirstHeader(req: IncomingMessage, key: string): string|null {
-  let headerValue = req.headers[key] || null;
-  if (headerValue && typeof headerValue !== 'string') {
-    headerValue = headerValue[0];
-  }
-  return headerValue;
-}
-
 function startSpanForRequest<T>(
     api: PluginTypes.Tracer, ctx: KoaContext, getNext: GetNextFn<T>): T {
   const req = ctx.req;
@@ -57,16 +49,16 @@ function startSpanForRequest<T>(
     name: req.url ? (urlParse(req.url).pathname || '') : '',
     url: req.url,
     method: req.method,
-    traceContext: getFirstHeader(req, api.constants.TRACE_CONTEXT_HEADER_NAME),
+    traceContext: api.propagation.extract(key => req.headers[key] || null),
     skipFrames: 2
   };
   return api.runInRootSpan(options, root => {
     // Set response trace context.
-    const responseTraceContext = api.getResponseTraceContext(
-        options.traceContext || null, api.isRealSpan(root));
+    const responseTraceContext =
+        api.getResponseContext(options.traceContext, api.isRealSpan(root));
     if (responseTraceContext) {
-      res.setHeader(
-          api.constants.TRACE_CONTEXT_HEADER_NAME, responseTraceContext);
+      api.propagation.inject(
+          (k, v) => res.setHeader(k, v), responseTraceContext);
     }
 
     if (!api.isRealSpan(root)) {

--- a/src/plugins/plugin-restify.ts
+++ b/src/plugins/plugin-restify.ts
@@ -52,17 +52,17 @@ function patchRestify(restify: Restify5, api: PluginTypes.Tracer) {
       name: req.path(),
       url: req.url,
       method: req.method,
-      traceContext: req.header(api.constants.TRACE_CONTEXT_HEADER_NAME),
+      traceContext: api.propagation.extract(key => req.header(key) || null),
       skipFrames: 1
     };
 
     api.runInRootSpan(options, rootSpan => {
       // Set response trace context.
-      const responseTraceContext = api.getResponseTraceContext(
+      const responseTraceContext = api.getResponseContext(
           options.traceContext, api.isRealSpan(rootSpan));
       if (responseTraceContext) {
-        res.header(
-            api.constants.TRACE_CONTEXT_HEADER_NAME, responseTraceContext);
+        api.propagation.inject(
+            (k, v) => res.setHeader(k, v), responseTraceContext);
       }
 
       if (!api.isRealSpan(rootSpan)) {

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -86,11 +86,15 @@ export abstract class BaseSpanData implements Span {
   }
 
   getTraceContext() {
-    return traceUtil.generateTraceContext({
+    return traceUtil.generateTraceContext(this.getContext());
+  }
+
+  getContext() {
+    return {
       traceId: this.trace.traceId.toString(),
       spanId: this.span.spanId.toString(),
       options: 1  // always traced
-    });
+    };
   }
 
   // tslint:disable-next-line:no-any
@@ -196,6 +200,9 @@ function createPhantomSpanData<T extends SpanType>(spanType: T): Span&
       {
         getTraceContext() {
           return '';
+        },
+        getContext() {
+          return null;
         },
         // tslint:disable-next-line:no-any
         addLabel(key: string, value: any) {},

--- a/src/trace-api.ts
+++ b/src/trace-api.ts
@@ -59,7 +59,7 @@ export enum TraceContextHeaderBehavior {
 export interface StackdriverTracerConfig extends TracePolicyConfig {
   enhancedDatabaseReporting: boolean;
   contextHeaderBehavior: TraceContextHeaderBehavior;
-  propagation: string[];
+  propagation: Array<string|Propagation>;
   rootSpanNameOverride: (path: string) => string;
   spansPerTraceSoftLimit: number;
   spansPerTraceHardLimit: number;
@@ -159,8 +159,13 @@ export class StackdriverTracer implements Tracer {
     this.config = config;
     this.policy = new TracePolicy(config);
     this.enabled = true;
-    this.propagationModules =
-        config.propagation.map(propModulePath => require(propModulePath));
+    this.propagationModules = config.propagation.map(propModule => {
+      if (typeof propModule === 'string') {
+        return require(propModule);
+      } else {
+        return propModule;
+      }
+    });
   }
 
   /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,6 +19,8 @@ import * as sourceMapSupport from 'source-map-support';
 const {hexToDec, decToHex}: {[key: string]: (input: string) => string} =
     require('hex2dec');
 
+export {hexToDec, decToHex};
+
 // This symbol must be exported (for now).
 // See: https://github.com/Microsoft/TypeScript/issues/20080
 export const kSingleton = Symbol();

--- a/test/fixtures/plugin-fixtures.json
+++ b/test/fixtures/plugin-fixtures.json
@@ -39,7 +39,7 @@
   },
   "grpc1.7": {
     "dependencies": {
-      "grpc": "^1.7.0"
+      "grpc": "~1.17.0"
     }
   },
   "hapi-plugin-mysql3": {

--- a/test/fixtures/propagation-local.js
+++ b/test/fixtures/propagation-local.js
@@ -1,0 +1,8 @@
+module.exports = {
+  extract: (getter) => {
+    return JSON.parse(getter.getHeader('my-trace-header'));
+  },
+  inject: (setter, context) => {
+    context && setter.setHeader('my-trace-header', JSON.stringify(context));
+  }
+};

--- a/test/plugins/common.ts
+++ b/test/plugins/common.ts
@@ -70,6 +70,7 @@ shimmer.wrap(trace, 'start', function(original) {
       samplingRate: 0,
       ignoreUrls: [],
       ignoreMethods: [],
+      propagation: ['@opencensus/propagation-stackdriver'],
       spansPerTraceSoftLimit: Infinity,
       spansPerTraceHardLimit: Infinity
     }, new TestLogger());

--- a/test/test-config.ts
+++ b/test/test-config.ts
@@ -24,6 +24,7 @@ import * as testTraceModule from './trace';
 import { NormalizedConfig } from '../src/tracing';
 import { StackdriverTracer } from '../src/trace-api';
 import {Logger} from '../src/logger';
+import { Propagation } from '../src/plugin-types';
 
 describe('Behavior set by config for CLS', () => {
   const useAH = semver.satisfies(process.version, '>=8');
@@ -133,16 +134,21 @@ describe('Behavior set by config for Tracer', () => {
   });
 
   describe('Propagation behavior', () => {
+    const propagationString = `${__dirname}/fixtures/propagation-local`;
+    const fakePropagation = { extract: () => null, inject: () => {} };
     const testCases: Array<{
       // tslint:disable-next-line:no-any
       input: any;
-      expected: string[];
+      expected: Array<string|Propagation>;
     }> = [{
-      input: 'hi',
-      expected: ['hi']
+      input: propagationString,
+      expected: [propagationString]
     }, {
-      input: ['hi', 'bye'],
-      expected: ['hi', 'bye']
+      input: [propagationString, fakePropagation],
+      expected: [propagationString, fakePropagation]
+    }, {
+      input: fakePropagation,
+      expected: [fakePropagation]
     }, {
       input: '',
       expected: []

--- a/test/test-config.ts
+++ b/test/test-config.ts
@@ -132,6 +132,37 @@ describe('Behavior set by config for Tracer', () => {
     testTraceModule.setTracingForTest(testTraceModule.TestTracing);
   });
 
+  describe('Propagation behavior', () => {
+    const testCases: Array<{
+      // tslint:disable-next-line:no-any
+      input: any;
+      expected: string[];
+    }> = [{
+      input: 'hi',
+      expected: ['hi']
+    }, {
+      input: ['hi', 'bye'],
+      expected: ['hi', 'bye']
+    }, {
+      input: '',
+      expected: []
+    }, {
+      input: null,
+      expected: []
+    }, {
+      input: undefined,
+      expected: ['@opencensus/propagation-stackdriver']
+    }];
+    for (const testCase of testCases) {
+      it(`should arrify a user input as expected: "${testCase.input}"`, () => {
+        testTraceModule.start({
+          propagation: testCase.input
+        });
+        const config = getCapturedConfig();
+        assert.deepStrictEqual(config.propagation, testCase.expected);
+      });
+    }
+  });
 
   describe('Context header behavior', () => {
     it('should copy over an explicitly-set value', () => {

--- a/test/test-plugin-loader.ts
+++ b/test/test-plugin-loader.ts
@@ -51,6 +51,7 @@ describe('Trace Plugin Loader', () => {
               contextHeaderBehavior: TraceContextHeaderBehavior.DEFAULT,
               rootSpanNameOverride: (name: string) => name,
               projectId: '0',
+              propagation: ['@opencensus/propagation-stackdriver'],
               spansPerTraceSoftLimit: Infinity,
               spansPerTraceHardLimit: Infinity
             },

--- a/test/test-trace-api.ts
+++ b/test/test-trace-api.ts
@@ -360,7 +360,7 @@ describe('Trace Interface', () => {
       it('should support multiple mechanisms if provided', () => {
         const tracer = createTraceAgent({
           propagation: [
-            `${__dirname}/fixtures/propagation-local`,
+            require(`${__dirname}/fixtures/propagation-local`),
             '@opencensus/propagation-stackdriver'
           ]
         });


### PR DESCRIPTION
Fixes #949

This feature allows users to supply a `Propagation` (or an absolute path to a file that exports that interface) to specify how trace context headers are injected and extracted from HTTP requests. It also replaces the built-in propagation mechanism with that of `@opencensus/propagation-stackdriver`, which has the same behavior.

Some notes:
* Some OpenCensus propagation libraries either don't export a consistent interface or have implementation bugs, so they won't work out-of-the-box as of yet.
* The propagation object exposed through the `StackdriverTracer` object doesn't have the same interface as the input object, the latter of which is modeled on OpenCensus while the former is just something I deemed to be more suitable for this module. Particularly of note is that OpenCensus treats all span IDs as length-16 hex strings, while we use decimal integer strings.
* It may be better _not_ to accept an OpenCensus `Propagation` object because of the above reasons. I'm open to discussion on this.