### PR TITLE
fix: wrap gRPC server async handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "node": ">=6"
   },
   "devDependencies": {
+    "@grpc/proto-loader": "^0.3.0",
     "@types/builtin-modules": "^2.0.0",
     "@types/console-log-level": "^1.4.0",
     "@types/continuation-local-storage": "^3.2.1",
@@ -62,7 +63,6 @@
     "@types/node": "~10.7.2",
     "@types/once": "^1.4.0",
     "@types/pify": "^3.0.0",
-    "@types/protobufjs": "^5.0.31",
     "@types/proxyquire": "^1.3.28",
     "@types/request": "^2.48.1",
     "@types/semver": "^5.4.0",

--- a/test/test-grpc-async-handler.ts
+++ b/test/test-grpc-async-handler.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as protoLoader from '@grpc/proto-loader';
+import * as grpcModule from 'grpc';
+
+import {Tester, TesterClient} from './test-grpc-proto';
+import * as traceTestModule from './trace';
+import {describeInterop} from './utils';
+
+type Grpc = typeof grpcModule;
+
+const PORT = 50051;
+
+describeInterop<Grpc>('grpc', (fixture) => {
+  let grpc: Grpc;
+  let testerService: protoLoader.ServiceDefinition;
+
+  before(async () => {
+    traceTestModule.setPluginLoaderForTest();
+    traceTestModule.setCLSForTest();
+    traceTestModule.start();
+    grpc = fixture.require();
+    const proto =
+        await protoLoader.load(`${__dirname}/fixtures/test-grpc.proto`);
+    testerService = proto['nodetest.Tester'];
+  });
+
+  afterEach(() => {
+    traceTestModule.clearTraceData();
+  });
+
+  after(() => {
+    traceTestModule.setPluginLoaderForTest(traceTestModule.TestPluginLoader);
+    traceTestModule.setCLSForTest(traceTestModule.TestCLS);
+  });
+
+  describe('Server', () => {
+    let server: grpcModule.Server;
+    let client: TesterClient;
+
+    before(() => {
+      server = new grpc.Server();
+      server.addService<Tester>(testerService, {
+        testUnary: async (call, callback) => {
+          callback(null, {n: 0});
+        },
+        testClientStream: async (call, callback) => {
+          callback(null, {n: 0});
+        },
+        testServerStream: async (call) => {
+          call.write({n: 0});
+          call.end();
+        },
+        testBidiStream: async (call) => {
+          call.write({n: 0});
+          call.end();
+        }
+      });
+      server.bind(`localhost:${PORT}`, grpc.ServerCredentials.createInsecure());
+      server.start();
+
+      // TesterClient is a class.
+      // tslint:disable-next-line:variable-name
+      const TesterClient =
+          grpc.makeGenericClientConstructor(testerService, 'Tester', {});
+      client = new TesterClient(
+                   `localhost:${PORT}`, grpc.credentials.createInsecure()) as
+          TesterClient;
+    });
+
+    after(() => {
+      server.forceShutdown();
+    });
+
+    it('should work with async unary call handlers', async () => {
+      const tracer = traceTestModule.get();
+      await tracer.runInRootSpan({name: 'client-outer'}, async (span) => {
+        await new Promise(
+            (resolve, reject) => client.TestUnary(
+                {n: 0}, (err, res) => err ? reject(err) : resolve()));
+        span.endSpan();
+      });
+      // Verify that a server trace was written.
+      // This function does the assertion underneath the covers.
+      traceTestModule.getOneSpan(
+          span => span.name === 'grpc:/nodetest.Tester/TestUnary' &&
+              span.kind === 'RPC_SERVER');
+    });
+
+    it('should work with async client streaming handlers', async () => {
+      const tracer = traceTestModule.get();
+      await tracer.runInRootSpan({name: 'client-outer'}, async (span) => {
+        await new Promise(
+            (resolve, reject) =>
+                client
+                    .TestClientStream(
+                        (err, res) => err ? reject(err) : resolve())
+                    .end());
+        span.endSpan();
+      });
+      // Verify that a server trace was written.
+      // This function does the assertion underneath the covers.
+      traceTestModule.getOneSpan(
+          span => span.name === 'grpc:/nodetest.Tester/TestClientStream' &&
+              span.kind === 'RPC_SERVER');
+    });
+
+    it('should work with async server streaming handlers', async () => {
+      const tracer = traceTestModule.get();
+      await tracer.runInRootSpan({name: 'client-outer'}, async (span) => {
+        await new Promise(
+            (resolve, reject) => client.TestServerStream({n: 0})
+                                     .on('error', reject)
+                                     .on('data', () => {})
+                                     .on('end', resolve));
+        span.endSpan();
+      });
+      // Verify that a server trace was written.
+      // This function does the assertion underneath the covers.
+      traceTestModule.getOneSpan(
+          span => span.name === 'grpc:/nodetest.Tester/TestServerStream' &&
+              span.kind === 'RPC_SERVER');
+    });
+
+    it('should work with async bidi streaming handlers', async () => {
+      const tracer = traceTestModule.get();
+      await tracer.runInRootSpan({name: 'client-outer'}, async (span) => {
+        await new Promise(
+            (resolve, reject) => client.TestBidiStream()
+                                     .on('error', reject)
+                                     .on('data', () => {})
+                                     .on('end', resolve));
+        span.endSpan();
+      });
+      // Verify that a server trace was written.
+      // This function does the assertion underneath the covers.
+      traceTestModule.getOneSpan(
+          span => span.name === 'grpc:/nodetest.Tester/TestBidiStream' &&
+              span.kind === 'RPC_SERVER');
+    });
+  });
+});

--- a/test/test-grpc-proto.d.ts
+++ b/test/test-grpc-proto.d.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { handleUnaryCall, handleClientStreamingCall, handleServerStreamingCall, handleBidiStreamingCall, Client, requestCallback, ClientUnaryCall, ClientWritableStream, ClientReadableStream, ClientDuplexStream } from 'grpc';
+
+export type TestRequest = { n: number };
+export type TestResponse = { n: number };
+export type Tester = {
+  TestUnary?: handleUnaryCall<TestRequest, TestResponse>;
+  TestClientStream?: handleClientStreamingCall<TestRequest, TestResponse>;
+  TestServerStream?: handleServerStreamingCall<TestRequest, TestResponse>;
+  TestBidiStream?: handleBidiStreamingCall<TestRequest, TestResponse>;
+  testUnary?: handleUnaryCall<TestRequest, TestResponse>;
+  testClientStream?: handleClientStreamingCall<TestRequest, TestResponse>;
+  testServerStream?: handleServerStreamingCall<TestRequest, TestResponse>;
+  testBidiStream?: handleBidiStreamingCall<TestRequest, TestResponse>;
+};
+
+// Incomplete definition for Tester client. Overloads and lowercase aliases are
+// not included for now, as they're not used anywhere.
+export type TesterClient = Client & {
+  TestUnary: (arg: TestRequest, cb: requestCallback<TestResponse>) => ClientUnaryCall;
+  TestClientStream: (cb: requestCallback<TestResponse>) => ClientWritableStream<TestRequest>;
+  TestServerStream: (arg: TestRequest) => ClientReadableStream<TestResponse>;
+  TestBidiStream: () => ClientDuplexStream<TestRequest, TestResponse>;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
     "test/test-config-plugins.ts",
     "test/test-default-ignore-ah-health.ts",
     "test/test-env-log-level.ts",
+    "test/test-grpc-async-handler.ts",
     "test/test-modules-loaded-before-agent.ts",
     "test/test-plugin-loader.ts",
     "test/test-span-data.ts",


### PR DESCRIPTION
Fixes #952

`plugin-grpc.ts` is best viewed with `?w=1`.