### PR TITLE
Output `'noPluginName'` in trace-api log messages where pluginName is undefined

### DIFF
--- a/src/trace-api.ts
+++ b/src/trace-api.ts
@@ -103,7 +103,7 @@ export class StackdriverTracer implements Tracer {
    */
   constructor(name: string) {
     this.pluginName = name;
-    this.pluginNameToLog = this.pluginName ? this.pluginName : 'noPluginName';
+    this.pluginNameToLog = this.pluginName ? this.pluginName : 'no-plugin-name';
     this.disable();  // disable immediately
   }
 


### PR DESCRIPTION
This will change log messages like this from:

```
[JS] @google-cloud/trace-agent DEBUG TraceApi#createChildSpan: [undefined] Created child span [doSomething()]
[JS] @google-cloud/trace-agent DEBUG TraceApi#createChildSpan: [undefined] Created child span [doSomething() -> browserStart]
```

To this:

```
[JS] @google-cloud/trace-agent DEBUG TraceApi#createChildSpan: [noPluginName] Created child span [doSomething()]
[JS] @google-cloud/trace-agent DEBUG TraceApi#createChildSpan: [noPluginName] Created child span [doSomething() -> browserStart]
```