### PR TITLE
chore: 3.5.2 release proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/trace-agent",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Node.js Support for StackDriver Trace",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",


### PR DESCRIPTION
[Release Notes](https://github.com/googleapis/cloud-trace-nodejs/releases/tag/untagged-e0651471b9f47020551c)