### PR TITLE
test: test hapi tails

### DIFF
--- a/test/test-trace-hapi-tails.ts
+++ b/test/test-trace-hapi-tails.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import axiosModule from 'axios';
+import * as semver from 'semver';
+
+import * as testTraceModule from './trace';
+import {assertSpanDuration, wait} from './utils';
+import {Hapi17} from './web-frameworks/hapi17';
+import {Hapi12, Hapi15, Hapi16, Hapi8} from './web-frameworks/hapi8_16';
+
+// The list of web frameworks to test.
+const FRAMEWORKS = [Hapi12, Hapi15, Hapi16, Hapi8, Hapi17];
+
+describe('Web framework tracing', () => {
+  let axios: typeof axiosModule;
+  before(() => {
+    testTraceModule.setCLSForTest();
+    testTraceModule.setPluginLoaderForTest();
+    testTraceModule.start();
+    axios = require('axios');
+  });
+
+  after(() => {
+    testTraceModule.setCLSForTest(testTraceModule.TestCLS);
+    testTraceModule.setPluginLoaderForTest(testTraceModule.TestPluginLoader);
+  });
+
+  FRAMEWORKS.forEach((webFrameworkConstructor) => {
+    const commonName = webFrameworkConstructor.commonName;
+    const versionRange = webFrameworkConstructor.versionRange;
+
+    // Skip this set for incompatible versions of Node
+    const skip = !semver.satisfies(process.version, versionRange);
+
+    (skip ? describe.skip : describe)(`Tracing ${commonName}`, () => {
+      // How this test works:
+      // On some WebFramework implementations (currently just Hapi), we can
+      // add "tail work" that is allowed to finish after the request ends.
+      // Hapi 8-16 provides built-in support to keep track of these types of
+      // calls, while Hapi 17 provides a more general mechanism for managing
+      // request lifecycle (both before and after the response has been sent.)
+      // Although the Trace Agent itself doesn't have any special behavior
+      // to account for the Hapi APIs, we would expect that a user using the
+      // tails API to observe a child span with the correct tail duration.
+      it('Traces tail calls correctly', async () => {
+        const framework = new webFrameworkConstructor();
+        try {
+          // "tail work" which will complete independent of the server response.
+          framework.addHandler({
+            path: '/tail',
+            hasResponse: false,
+            blocking: false,
+            fn: async () => {
+              const child =
+                  testTraceModule.get().createChildSpan({name: 'my-tail-work'});
+              await wait(100);
+              child.endSpan();
+            }
+          });
+          framework.addHandler({
+            path: '/tail',
+            hasResponse: true,
+            fn: async () => (
+                {statusCode: 200, message: 'there is still work to be done'})
+          });
+          // A Promise that resolves when the tail call is finished.
+          const tailCallMade =
+              new Promise((resolve) => framework.once('tail', resolve));
+          // Start listening.
+          const port = await framework.listen(0);
+          // Hit the server.
+          await testTraceModule.get().runInRootSpan(
+              {name: 'outer'}, async (span) => {
+                await axios.get(`http://localhost:${port}/tail`);
+                span.endSpan();
+              });
+          // A child span should have been observed by the Trace Writer.
+          const childSpanBeforeEnd =
+              testTraceModule.getOneSpan(span => span.name === 'my-tail-work');
+          assert.ok(!childSpanBeforeEnd.endTime);
+          // Simulate a "flush". The Trace Writer itself will not publish a
+          // span that doesn't have an end time.
+          testTraceModule.clearTraceData();
+          await tailCallMade;
+          // The same child span should have been observed again by the
+          // Trace Writer.
+          const childSpanAfterEnd =
+              testTraceModule.getOneSpan(span => span.name === 'my-tail-work');
+          assert.strictEqual(
+              childSpanAfterEnd.spanId, childSpanBeforeEnd.spanId);
+          // The child span only needs to be at least 100ms.
+          assertSpanDuration(childSpanAfterEnd, [100, Infinity]);
+        } finally {
+          framework.shutdown();
+          testTraceModule.clearTraceData();
+        }
+      });
+    });
+  });
+});

--- a/test/test-trace-web-frameworks.ts
+++ b/test/test-trace-web-frameworks.ts
@@ -92,6 +92,7 @@ describe('Web framework tracing', () => {
         webFramework.addHandler({
           path: '/two-handlers',
           hasResponse: false,
+          blocking: true,
           fn: async () => {
             await wait(DEFAULT_SPAN_DURATION / 2);
           }

--- a/test/web-frameworks/base.ts
+++ b/test/web-frameworks/base.ts
@@ -29,12 +29,19 @@ export interface WebFrameworkResponse {
  * The underlying type of objects passed to WebFramework#addHandler.
  */
 export type WebFrameworkAddHandlerOptions = {
+  // The path which will invoke the handler.
   path: string;
 }&({
+  // This handler doesn't provide the response.
   hasResponse: false;
+  // Whether or not this handler should block the next handler.
+  blocking: boolean;
+  // The handler function.
   fn: (incomingHeaders: IncomingHttpHeaders) => Promise<void>;
 }|{
+  // This handler provides a response.
   hasResponse: true;
+  // The handler function.
   fn: (incomingHeaders: IncomingHttpHeaders) => Promise<WebFrameworkResponse>;
 });
 

--- a/test/web-frameworks/connect.ts
+++ b/test/web-frameworks/connect.ts
@@ -34,6 +34,11 @@ export class Connect3 implements WebFramework {
   }
 
   addHandler(options: WebFrameworkAddHandlerOptions): void {
+    if (!options.hasResponse && !options.blocking) {
+      throw new Error(`${
+          this.constructor
+              .name} wrapper for testing doesn't support non-blocking handlers.`);
+    }
     this.app.use(
         options.path,
         async (

--- a/test/web-frameworks/express.ts
+++ b/test/web-frameworks/express.ts
@@ -34,6 +34,11 @@ export class Express4 implements WebFramework {
   }
 
   addHandler(options: WebFrameworkAddHandlerOptions): void {
+    if (!options.hasResponse && !options.blocking) {
+      throw new Error(`${
+          this.constructor
+              .name} wrapper for testing doesn't support non-blocking handlers.`);
+    }
     this.app.get(options.path, async (req, res, next) => {
       let response: WebFrameworkResponse|void;
       try {

--- a/test/web-frameworks/koa1.ts
+++ b/test/web-frameworks/koa1.ts
@@ -36,6 +36,11 @@ export class Koa1 implements WebFramework {
   }
 
   addHandler(options: WebFrameworkAddHandlerOptions): void {
+    if (!options.hasResponse && !options.blocking) {
+      throw new Error(`${
+          this.constructor
+              .name} wrapper for testing doesn't support non-blocking handlers.`);
+    }
     this.app.use(function*(next) {
       if (this.request.path === options.path) {
         // Context doesn't automatically get propagated to yielded functions.

--- a/test/web-frameworks/koa2.ts
+++ b/test/web-frameworks/koa2.ts
@@ -35,6 +35,11 @@ export class Koa2 implements WebFramework {
   }
 
   addHandler(options: WebFrameworkAddHandlerOptions): void {
+    if (!options.hasResponse && !options.blocking) {
+      throw new Error(`${
+          this.constructor
+              .name} wrapper for testing doesn't support non-blocking handlers.`);
+    }
     this.app.use(async (ctx, next) => {
       if (ctx.request.path === options.path) {
         const response = await options.fn(ctx.req.headers);

--- a/test/web-frameworks/restify.ts
+++ b/test/web-frameworks/restify.ts
@@ -29,6 +29,11 @@ export class Restify implements WebFramework {
   }
 
   addHandler(options: WebFrameworkAddHandlerOptions): void {
+    if (!options.hasResponse && !options.blocking) {
+      throw new Error(`${
+          this.constructor
+              .name} wrapper for testing doesn't support non-blocking handlers.`);
+    }
     if (options.hasResponse) {
       this.server.get(options.path, async (req, res, next) => {
         let response: WebFrameworkResponse;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,7 @@
     "test/test-trace-api.ts",
     "test/test-trace-api-none-cls.ts",
     "test/test-trace-cluster.ts",
+    "test/test-trace-hapi-tails.ts",
     "test/test-trace-policy.ts",
     "test/test-trace-uncaught-exception.ts",
     "test/test-trace-web-frameworks.ts",


### PR DESCRIPTION
Fixes #382

Since child spans are now allowed to track tail latencies, this PR adds a test to ensure that users of the Hapi tails API (up to v16, but also including the more general recommended mechanism in the [v17 release notes](https://github.com/hapijs/hapi/issues/3658) under "Misc") can observe these child spans.

Note that child spans still cannot begin _after_ a root span has ended.