### PR TITLE
chore: 3.6.0 release proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/trace-agent",
-  "version": "3.5.2",
+  "version": "3.6.0",
   "description": "Node.js Support for StackDriver Trace",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",


### PR DESCRIPTION
[Release Notes](https://github.com/googleapis/cloud-trace-nodejs/releases/tag/untagged-aa9f39d9e9a86e0db90b)