### PR TITLE
fix: don't let trace context injection throw

### DIFF
--- a/src/plugins/plugin-http.ts
+++ b/src/plugins/plugin-http.ts
@@ -28,6 +28,9 @@ type HttpModule = typeof httpModule;
 type HttpsModule = typeof httpsModule;
 type RequestFunction = typeof request;
 
+const ERR_HTTP_HEADERS_SENT = 'ERR_HTTP_HEADERS_SENT';
+const ERR_HTTP_HEADERS_SENT_MSG = 'Can\'t set headers after they are sent.';
+
 // tslint:disable:no-any
 const isString = is.string as (value: any) => value is string;
 // url.URL is used for type checking, but doesn't exist in Node <7.
@@ -130,6 +133,8 @@ function makeRequestTrace(
     // inject the trace context header instead of using ClientRequest#setHeader.
     // (We don't do this generally because cloning the options object is an
     // expensive operation.)
+    // See https://github.com/googleapis/cloud-trace-nodejs/pull/766 for a full
+    // explanation.
     let traceHeaderPreinjected = false;
     if (hasExpectHeader(options)) {
       traceHeaderPreinjected = true;
@@ -187,9 +192,14 @@ function makeRequestTrace(
         req.setHeader(
             api.constants.TRACE_CONTEXT_HEADER_NAME, span.getTraceContext());
       } catch (e) {
-        // Swallow the error.
-        // This would happen in the pathological case where the Expect header
-        // exists but is not detected by hasExpectHeader.
+        if (e.code === ERR_HTTP_HEADERS_SENT ||
+            e.message === ERR_HTTP_HEADERS_SENT_MSG) {
+          // Swallow the error.
+          // This would happen in the pathological case where the Expect header
+          // exists but is not detected by hasExpectHeader.
+        } else {
+          throw e;
+        }
       }
     }
     return req;

--- a/test/plugins/test-trace-http.ts
+++ b/test/plugins/test-trace-http.ts
@@ -192,20 +192,6 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
           }
         },
         {
-          description: 'calling http.get with Expect header',
-          fn: async () => {
-            const waitForResponse = new WaitForResponse();
-            const req = http.get(
-                {
-                  port,
-                  rejectUnauthorized: false,
-                  headers: {Expect: '100-continue'}
-                },
-                waitForResponse.handleResponse);
-            await waitForResponse.done;
-          }
-        },
-        {
           description: 'calling http.get, but timing out and emitting an error',
           fn: async () => {
             // server.server is a handle to the underlying server in an
@@ -219,6 +205,21 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
             await waitForResponse.done;
           }
         },
+        ...['Expect', 'expect', 'EXPECT', 'eXpEcT'].map(
+            key => ({
+              description: `calling http.get with ${key} header`,
+              fn: async () => {
+                const waitForResponse = new WaitForResponse();
+                http.get(
+                    {
+                      port,
+                      rejectUnauthorized: false,
+                      headers: {[key]: '100-continue'}
+                    },
+                    waitForResponse.handleResponse);
+                await waitForResponse.done;
+              }
+            }))
       ];
 
       beforeEach(async () => {


### PR DESCRIPTION
It's possible for `setHeader` to throw if an outgoing request was created with a header `Expect` but not capitalized exactly that way. This change makes checking for the `expect` header a little more robust, and also swallows an error that would be thrown for further unexpected capitalizations.

It's possible that `hasExpectHeader` can either (1) stay the same or (2) be even more robust and actually iterate through all header keys to do a case-insensitive check. I'm definitely OK with the first option, the second option might have too much overhead to accomadate for a rare issue.