### PR TITLE
chore: add node 12 ci job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ workflows:
       - node8
       - node10
       - node11
+      - node12
   tests:
     jobs:
       - node8:
@@ -98,11 +99,14 @@ workflows:
           filters: *release_tags
       - node11:
           filters: *release_tags
+      - node12:
+          filters: *release_tags
       - publish_npm:
           requires:
             - node8
             - node10
             - node11
+            - node12
           filters:
             branches:
               ignore: /.*/
@@ -134,6 +138,14 @@ jobs:
       CODECOV_ENV: node11
     docker:
       - image: node:11
+      - *mongo_service
+      - *redis_service
+      - *postgres_service
+      - *mysql_service
+    <<: *unit_tests
+  node12:
+    docker:
+      - image: node:12
       - *mongo_service
       - *redis_service
       - *postgres_service

--- a/test/fixtures/plugin-fixtures.json
+++ b/test/fixtures/plugin-fixtures.json
@@ -29,17 +29,9 @@
       "google-gax": "^0.16.0"
     }
   },
-  "grpc1.6": {
+  "grpc1.20": {
     "dependencies": {
-      "grpc": "~1.6.0"
-    },
-    "engines": {
-      "node": "<10"
-    }
-  },
-  "grpc1.7": {
-    "dependencies": {
-      "grpc": "^1.7.0"
+      "grpc": "^1.20.2"
     }
   },
   "hapi-plugin-mysql3": {

--- a/test/fixtures/plugin-fixtures.json
+++ b/test/fixtures/plugin-fixtures.json
@@ -171,14 +171,20 @@
       "hiredis": "^0.4.1",
       "redis": "~2.3.x"
     },
-    "_mainModule": "redis"
+    "_mainModule": "redis",
+    "engines": {
+      "node": "<12"
+    }
   },
   "redis2.3-hiredis0.5": {
     "dependencies": {
       "hiredis": "^0.5.0",
       "redis": "~2.3.x"
     },
-    "_mainModule": "redis"
+    "_mainModule": "redis",
+    "engines": {
+      "node": "<12"
+    }
   },
   "redis2.3": {
     "dependencies": {

--- a/test/plugins/test-trace-http2.ts
+++ b/test/plugins/test-trace-http2.ts
@@ -291,10 +291,17 @@ maybeSkipHttp2('Trace Agent integration with http2', () => {
               DEFAULT_SPAN_DURATION / 2,
               Date.now() - start,
             ]);
-            assert.strictEqual(
-              span.labels[TraceLabels.ERROR_DETAILS_NAME],
-              'Error [ERR_HTTP2_STREAM_ERROR]'
-            );
+            if (semver.satisfies(process.version, '>=12')) {
+              assert.strictEqual(
+                span.labels[TraceLabels.ERROR_DETAILS_NAME],
+                'Error'
+              );
+            } else {
+              assert.strictEqual(
+                span.labels[TraceLabels.ERROR_DETAILS_NAME],
+                'Error [ERR_HTTP2_STREAM_ERROR]'
+              );
+            }
             if (semver.satisfies(process.version, '>=9.11 || >=8.12')) {
               assert.strictEqual(
                 span.labels[TraceLabels.ERROR_DETAILS_MESSAGE],

--- a/test/plugins/test-trace-redis.ts
+++ b/test/plugins/test-trace-redis.ts
@@ -16,6 +16,7 @@
 'use strict';
 
 import { TraceLabels } from '../../src/trace-labels';
+import { describeInterop } from '../utils';
 
 // Prereqs:
 // Start docker daemon
@@ -27,15 +28,6 @@ var common = require('./common'/*.js*/);
 var RESULT_SIZE = 5;
 
 var assert = require('assert');
-var versions = {
-  redis0: './fixtures/redis0.12',
-  // Our patches are different on redis <=2.3, >2.3 <2.6, and >=2.6
-  redis2dot3: './fixtures/redis2.3',
-  redis2dot4: './fixtures/redis2.4',
-  redis2dotx: './fixtures/redis2.x',
-  redisHiredis04: './fixtures/redis2.3-hiredis0.4',
-  redisHiredis05: './fixtures/redis2.3-hiredis0.5'
-};
 
 describe('redis', function() {
   var agent;
@@ -50,89 +42,87 @@ describe('redis', function() {
   });
 
   var client;
-  Object.keys(versions).forEach(function(version) {
-    describe(version, function() {
-      var redis;
-      before(function() {
-        redis = require(versions[version]);
-      });
+  describeInterop('redis', function(fixture) {
+    var redis;
+    before(function() {
+      redis = fixture.require();
+    });
 
-      beforeEach(function(done) {
-        client = redis.createClient();
-        client.on('error', function(err) {
-          assert(false, 'redis error ' + err);
-        });
-        client.set('beforeEach', 42, function() {
-          common.cleanTraces();
+    beforeEach(function(done) {
+      client = redis.createClient();
+      client.on('error', function(err) {
+        assert(false, 'redis error ' + err);
+      });
+      client.set('beforeEach', 42, function() {
+        common.cleanTraces();
+        done();
+      });
+    });
+
+    afterEach(function(done) {
+      client.quit(function() {
+        common.cleanTraces();
+        done();
+      });
+    });
+
+    it('should accurately measure get time', function(done) {
+      common.runInTransaction(function(endTransaction) {
+        client.get('beforeEach', function(err, n) {
+          endTransaction();
+          assert.strictEqual(Number(n), 42);
+          var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-get'));
+          assert(trace);
           done();
         });
       });
+    });
 
-      afterEach(function(done) {
-        client.quit(function() {
-          common.cleanTraces();
+    it('should propagate context', function(done) {
+      common.runInTransaction(function(endTransaction) {
+        client.get('beforeEach', function(err, n) {
+          assert.ok(common.hasContext());
+          endTransaction();
           done();
         });
       });
+    });
 
-      it('should accurately measure get time', function(done) {
-        common.runInTransaction(function(endTransaction) {
-          client.get('beforeEach', function(err, n) {
-            endTransaction();
-            assert.strictEqual(Number(n), 42);
-            var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-get'));
-            assert(trace);
-            done();
-          });
+    it('should accurately measure set time', function(done) {
+      common.runInTransaction(function(endTransaction) {
+        client.set('key', 'redis_value', function(err) {
+          endTransaction();
+          var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-set'));
+          assert(trace);
+          done();
         });
       });
+    });
 
-      it('should propagate context', function(done) {
-        common.runInTransaction(function(endTransaction) {
-          client.get('beforeEach', function(err, n) {
-            assert.ok(common.hasContext());
-            endTransaction();
-            done();
-          });
+    it('should accurately measure hset time', function(done) {
+      common.runInTransaction(function(endTransaction) {
+        // Test error case as hset requires 3 parameters
+        client.hset('key', 'redis_value', function(err) {
+          endTransaction();
+          var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-hset'));
+          assert(trace);
+          done();
         });
       });
+    });
 
-      it('should accurately measure set time', function(done) {
-        common.runInTransaction(function(endTransaction) {
-          client.set('key', 'redis_value', function(err) {
-            endTransaction();
-            var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-set'));
-            assert(trace);
-            done();
-          });
-        });
-      });
-
-      it('should accurately measure hset time', function(done) {
-        common.runInTransaction(function(endTransaction) {
-          // Test error case as hset requires 3 parameters
-          client.hset('key', 'redis_value', function(err) {
-            endTransaction();
-            var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-hset'));
-            assert(trace);
-            done();
-          });
-        });
-      });
-
-      it('should remove trace frames from stack', function(done) {
-        common.runInTransaction(function(endTransaction) {
-          // Test error case as hset requires 3 parameters
-          client.hset('key', 'redis_value', function(err) {
-            endTransaction();
-            var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-hset'));
-            var labels = trace.labels;
-            var stackTrace = JSON.parse(labels[TraceLabels.STACK_TRACE_DETAILS_KEY]);
-            // Ensure that our patch is on top of the stack
-            assert(
-              stackTrace.stack_frame[0].method_name.indexOf('send_command_trace') !== -1);
-            done();
-          });
+    it('should remove trace frames from stack', function(done) {
+      common.runInTransaction(function(endTransaction) {
+        // Test error case as hset requires 3 parameters
+        client.hset('key', 'redis_value', function(err) {
+          endTransaction();
+          var trace = common.getMatchingSpan(redisPredicate.bind(null, 'redis-hset'));
+          var labels = trace.labels;
+          var stackTrace = JSON.parse(labels[TraceLabels.STACK_TRACE_DETAILS_KEY]);
+          // Ensure that our patch is on top of the stack
+          assert(
+            stackTrace.stack_frame[0].method_name.indexOf('send_command_trace') !== -1);
+          done();
         });
       });
     });

--- a/test/test-cls-ah.ts
+++ b/test/test-cls-ah.ts
@@ -67,7 +67,7 @@ maybeSkip(describe)('AsyncHooks-based CLS', () => {
   });
 
   it('Correctly assumes the type of Promise resources', () => {
-    const actual: Array<Promise<void>> = [];
+    let numPromiseInitHookInvocations = 0;
     const expected: Array<Promise<void>> = [];
     const hook = asyncHooks
       .createHook({
@@ -78,14 +78,14 @@ maybeSkip(describe)('AsyncHooks-based CLS', () => {
           resource: { promise: Promise<void> }
         ) => {
           if (type === 'PROMISE') {
-            actual.push(resource.promise);
+            numPromiseInitHookInvocations++;
           }
         },
       })
       .enable();
     expected.push(Promise.resolve());
-    expected.push(actual[0].then(() => {}));
-    assert.deepStrictEqual(actual, expected);
+    expected.push(expected[0].then(() => {}));
+    assert.deepStrictEqual(numPromiseInitHookInvocations, expected.length);
     hook.disable();
   });
 


### PR DESCRIPTION
This change adds Node 12 as a Circle CI job, and de-facto adds support for Node 12. The following changes need to be made in the process:

* Because `hiredis` doesn't seem to build on Node 12 I've also opted to not test it on Node 12. I recommend viewing [files changed with `?w=1`](https://github.com/googleapis/cloud-trace-nodejs/pull/1002/files?w=1) to see a more illustrative diff. (Also see [`describeInterop` implementation notes](https://github.com/googleapis/cloud-trace-nodejs/blob/v3.6.1/test/utils.ts#L186-L200))
* References to Promises no longer exist on `PROMISE`-type async resources, so I've amended a test to count an expected number of async hook invocations rather than compare exact values retrieved from those async hook invocations.
* Node 12 appears to have a bug where async hook objects can't be re-enabled after being disabled.  See #1017. In the meantime, before this bug gets fixed, I've changed our implementation to create a dummy async hook that is always enabled. (This allows some tests to pass, but there will be a performance penalty for customers that run the disabled trace agent, e.g. if they start the agent but with invalid credentials).
* Node 12 error messages have changed (at least in HTTP/2). I've amended the tests to account for this.