### PR TITLE
remove the hash from the ignoreUrls in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Optionally, you can pass a [configuration object](src/config.ts) to the `start()
 ```js
 require('@google-cloud/trace-agent').start({
   samplingRate: 5, // sample 5 traces per second, or at most 1 every 200 milliseconds.
-  ignoreUrls: [ /^\/ignore-me#/ ] // ignore the "/ignore-me" endpoint.
+  ignoreUrls: [ /^\/ignore-me/ ] // ignore the "/ignore-me" endpoint.
   ignoreMethods: [ 'options' ] // ignore requests with OPTIONS method (case-insensitive).
 });
 // ...


### PR DESCRIPTION
Hello, the docs for ignoreUrls have a mysterious hash that me and my team think may be a mistake in the docs. I have updated it to prevent others from having the same discussion.

... or maybe is has some mysterious power we can't figure out?