### PR TITLE
chore: 3.6.1 release proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/trace-agent",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Node.js Support for StackDriver Trace",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",


### PR DESCRIPTION
[Release Notes](https://github.com/googleapis/cloud-trace-nodejs/releases/tag/untagged-2d501a08e592789b8f1c)