### PR TITLE
feat: use souce-map-support wrapCallSite to apply source maps to call stacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@types/request": "^2.48.1",
     "@types/semver": "^6.0.0",
     "@types/shimmer": "^1.0.1",
+    "@types/source-map-support": "^0.5.0",
     "@types/tmp": "0.1.0",
     "@types/uuid": "^3.4.3",
     "axios": "^0.18.0",
@@ -91,7 +92,6 @@
     "pify": "^4.0.0",
     "retry-axios": "^1.0.0",
     "rimraf": "^2.6.2",
-    "source-map-support": "^0.5.6",
     "standard-version": "^5.0.0",
     "teeny-request": "^3.11.1",
     "timekeeper": "^2.0.0",
@@ -111,6 +111,7 @@
     "methods": "^1.1.1",
     "require-in-the-middle": "^4.0.0",
     "semver": "^6.0.0",
+    "source-map-support": "^0.5.12",
     "shimmer": "^1.2.0",
     "uuid": "^3.0.1"
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import * as path from 'path';
+import * as sourceMapSupport from 'source-map-support';
+
 const {hexToDec, decToHex}: {[key: string]: (input: string) => string} =
     require('hex2dec');
 
@@ -206,7 +207,7 @@ export function createStackTrace(
   const origPrepare = Error.prepareStackTrace;
   Error.prepareStackTrace =
       (error: Error, structured: NodeJS.CallSite[]): NodeJS.CallSite[] => {
-        return structured;
+        return structured.map(sourceMapSupport.wrapCallSite);
       };
   const e: {stack?: NodeJS.CallSite[]} = {};
   Error.captureStackTrace(e, constructorOpt);


### PR DESCRIPTION
This produces nice call stacks that display line and column numbers from transpiled TypeScript, Coffee Script, etc source files like this:

```
Callstack
runInSpan (/app/src/trace-util.ts:129:30)
runDispatcherInTrace [as runDispatcherInTrace] (/app/src/trace-util.ts:167:18)
source.asCallback (/app/src/dispatcher/simpleDispatcher.ts:57:29)
dispatchMessage (/app/src/source/natsSource.ts:141:9)
trace_util_1.runInSpan (/app/src/source/natsSource.ts:74:19)
that.runWithContext (/app/node_modules/@google-cloud/trace-agent/build/src/cls/async-hooks.js:143:49)
runWithContext [as runWithContext] (/app/node_modules/@google-cloud/trace-agent/build/src/cls/async-hooks.js:121:20)
contextWrapper (/app/node_modules/@google-cloud/trace-agent/build/src/cls/async-hooks.js:143:25)
tracing_1.tracer.runInRootSpan (/app/src/trace-util.ts:144:17)
cls_1.cls.get.runWithContext (/app/node_modules/@google-cloud/trace-agent/build/src/trace-api.js:193:20)
```