### PR TITLE
fix: Prevent filtered traces from biasing the sample rate

### DIFF
--- a/src/tracing-policy.ts
+++ b/src/tracing-policy.ts
@@ -117,9 +117,9 @@ export class TracePolicy {
    */
   shouldTrace(options: {timestamp: number, url: string, method: string}):
       boolean {
-    return this.sampler.shouldTrace(options.timestamp) &&
-        this.urlFilter.shouldTrace(options.url) &&
-        this.methodsFilter.shouldTrace(options.method);
+    return this.urlFilter.shouldTrace(options.url) &&
+        this.methodsFilter.shouldTrace(options.method) &&
+        this.sampler.shouldTrace(options.timestamp);
   }
 
   static always(): TracePolicy {


### PR DESCRIPTION
The `URLFilter` and `MethodsFilter` implementations are side-effect
free, and are safe to run in any order. However, `sampler.shouldTrace`
is not, a result of `true` from it has the side effect of altering the
trace window.

Expected behavior
=================

RPCs to a filtered URL or method should not affect sample rates of
unfiltered URLs or methods.

Actual behavior
===============

A high rate of RPCs relative to the sample rate that are filtered causes
the actual sampling to be biased and below the expected rate.

Suppose that external RPCs occur at the same frequency as interval as
health checks: the resulting sample rate will be approximately 1/2 the
specified rate, because it will be (about) a coin flip whether the first
request in an interval is a healthcheck or a valid RPC.

If the first request received within a sampling window has a filtered
url, `shouldTrace` will return false, because:

1. `this.sampler.shouldTrace` will return true
2. `this.urlFilter.shouldTrace` will return false
3. the && operation short-circuits and will not call
   `this.methodsFilter.shouldTrace`

Then if the second request received is to `/foobar` immediately
afterward, `shouldTrace` will return false!

1. `this.sampler.shouldTrace` returns false because the prior call
   changed the sampling window
2. the operation short-circuits

Fix
===

Call the side-effecting sampler method last.