### PR TITLE
chore: stop testing on node 6 in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,14 +87,11 @@ workflows:
               only:
                 - master
     jobs:
-      - node6
       - node8
       - node10
       - node11
   tests:
     jobs:
-      - node6:
-          filters: *release_tags
       - node8:
           filters: *release_tags
       - node10:
@@ -103,7 +100,6 @@ workflows:
           filters: *release_tags
       - publish_npm:
           requires:
-            - node6
             - node8
             - node10
             - node11
@@ -113,16 +109,6 @@ workflows:
             <<: *release_tags
 
 jobs:
-  node6:
-    environment:
-      CODECOV_ENV: node6
-    docker:
-      - image: node:6
-      - *mongo_service
-      - *redis_service
-      - *postgres_service
-      - *mysql_service
-    <<: *unit_tests
   node8:
     environment:
       CODECOV_ENV: node8


### PR DESCRIPTION
We've already "dropped" support for Node 6 in #1011, this allows us to start acting on that.