### PR TITLE
feat!: support user-specified context header propagation

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
   },
   "dependencies": {
     "@google-cloud/common": "^1.0.0",
+    "@opencensus/propagation-stackdriver": "0.0.11",
     "builtin-modules": "^3.0.0",
     "console-log-level": "^1.4.0",
     "continuation-local-storage": "^3.2.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,24 @@ export interface TracePolicy {
   shouldTrace: (requestDetails: RequestDetails) => boolean;
 }
 
+export type GetHeaderFunction = {
+  getHeader: (key: string) => string[]|string|undefined;
+};
+export type SetHeaderFunction = {
+  setHeader: (key: string, value: string) => void;
+};
+export interface OpenCensusPropagation {
+  extract: (getHeader: GetHeaderFunction) => {
+    traceId: string;
+    spanId: string;
+    options?: number
+  } | null;
+  inject: (setHeader: SetHeaderFunction, traceContext: {
+    traceId: string; spanId: string;
+    options?: number
+  }) => void;
+}
+
 /**
  * Available configuration options. All fields are optional. See the
  * defaultConfig object defined in this file for default assigned values.

--- a/src/config.ts
+++ b/src/config.ts
@@ -214,6 +214,13 @@ export interface Config {
   tracePolicy?: TracePolicy;
 
   /**
+   * If specified, the Trace Agent will use this context header propagation
+   * implementation instead of @opencensus/propagation-stackdriver, the default
+   * trace context header format.
+   */
+  propagation?: OpenCensusPropagation;
+
+  /**
    * Buffer the captured traces for `flushDelaySeconds` seconds before
    * publishing to the Stackdriver Trace API, unless the buffer fills up first.
    * Also see `bufferSize`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,10 @@ function initConfig(userConfig: Forceable<Config>): Forceable<TopLevelConfig> {
       contextHeaderBehavior: mergedConfig.contextHeaderBehavior as
           TraceContextHeaderBehavior
     },
-    overrides: {tracePolicy: mergedConfig.tracePolicy}
+    overrides: {
+      tracePolicy: mergedConfig.tracePolicy,
+      propagation: mergedConfig.propagation
+    }
   };
 }
 

--- a/src/plugins/plugin-grpc.ts
+++ b/src/plugins/plugin-grpc.ts
@@ -19,7 +19,7 @@ import * as grpcModule from 'grpc';  // for types only.
 import {Client, MethodDefinition, ServerReadableStream, ServerUnaryCall, StatusObject} from 'grpc';
 import * as shimmer from 'shimmer';
 
-import {Plugin, RootSpan, RootSpanOptions, Span, Tracer} from '../plugin-types';
+import {Plugin, RootSpan, RootSpanOptions, Span, TraceContext, Tracer} from '../plugin-types';
 
 // Re-definition of Metadata with private fields
 type Metadata = grpcModule.Metadata&{
@@ -116,9 +116,7 @@ function patchClient(client: ClientModule, api: Tracer) {
    * a falsey value, metadata will not be modified.
    */
   function setTraceContextFromString(
-      metadata: Metadata, stringifiedTraceContext: string): void {
-    const traceContext =
-        api.traceContextUtils.decodeFromString(stringifiedTraceContext);
+      metadata: Metadata, traceContext: TraceContext|null): void {
     if (traceContext) {
       const metadataValue =
           api.traceContextUtils.encodeAsByteArray(traceContext);
@@ -292,12 +290,11 @@ function unpatchClient(client: ClientModule) {
 function patchServer(server: ServerModule, api: Tracer) {
   /**
    * Returns a trace context on a Metadata object if it exists and is
-   * well-formed, or null otherwise. The result will be encoded as a string.
+   * well-formed, or null otherwise.
    * @param metadata The Metadata object from which trace context should be
    * retrieved.
    */
-  function getStringifiedTraceContext(metadata: grpcModule.Metadata): string|
-      null {
+  function getTraceContext(metadata: grpcModule.Metadata): TraceContext|null {
     const metadataValue =
         metadata.getMap()[api.constants.TRACE_CONTEXT_GRPC_METADATA_NAME] as
         Buffer;
@@ -305,13 +302,7 @@ function patchServer(server: ServerModule, api: Tracer) {
     if (!metadataValue) {
       return null;
     }
-    const traceContext =
-        api.traceContextUtils.decodeFromByteArray(metadataValue);
-    // Value is malformed.
-    if (!traceContext) {
-      return null;
-    }
-    return api.traceContextUtils.encodeAsString(traceContext);
+    return api.traceContextUtils.decodeFromByteArray(metadataValue);
   }
 
   /**
@@ -356,7 +347,7 @@ function patchServer(server: ServerModule, api: Tracer) {
       const rootSpanOptions = {
         name: requestName,
         url: requestName,
-        traceContext: getStringifiedTraceContext(call.metadata),
+        traceContext: getTraceContext(call.metadata),
         skipFrames: SKIP_FRAMES
       };
       return api.runInRootSpan(rootSpanOptions, (rootSpan) => {
@@ -410,7 +401,7 @@ function patchServer(server: ServerModule, api: Tracer) {
       const rootSpanOptions = {
         name: requestName,
         url: requestName,
-        traceContext: getStringifiedTraceContext(stream.metadata),
+        traceContext: getTraceContext(stream.metadata),
         skipFrames: SKIP_FRAMES
       } as RootSpanOptions;
       return api.runInRootSpan(rootSpanOptions, (rootSpan) => {
@@ -472,7 +463,7 @@ function patchServer(server: ServerModule, api: Tracer) {
       const rootSpanOptions = {
         name: requestName,
         url: requestName,
-        traceContext: getStringifiedTraceContext(stream.metadata),
+        traceContext: getTraceContext(stream.metadata),
         skipFrames: SKIP_FRAMES
       } as RootSpanOptions;
       return api.runInRootSpan(rootSpanOptions, (rootSpan) => {
@@ -532,7 +523,7 @@ function patchServer(server: ServerModule, api: Tracer) {
       const rootSpanOptions = {
         name: requestName,
         url: requestName,
-        traceContext: getStringifiedTraceContext(stream.metadata),
+        traceContext: getTraceContext(stream.metadata),
         skipFrames: SKIP_FRAMES
       } as RootSpanOptions;
       return api.runInRootSpan(rootSpanOptions, (rootSpan) => {

--- a/src/plugins/plugin-hapi.ts
+++ b/src/plugins/plugin-hapi.ts
@@ -34,34 +34,26 @@ type Hapi17Request = hapi_17.Request&{
   _execute: Hapi17RequestExecutePrivate;
 };
 
-function getFirstHeader(req: IncomingMessage, key: string): string|null {
-  let headerValue = req.headers[key] || null;
-  if (headerValue && typeof headerValue !== 'string') {
-    headerValue = headerValue[0];
-  }
-  return headerValue;
-}
-
 function instrument<T>(
     api: PluginTypes.Tracer, request: hapi_16.Request|hapi_17.Request,
     continueCb: () => T): T {
   const req = request.raw.req;
   const res = request.raw.res;
   const originalEnd = res.end;
-  const options: PluginTypes.RootSpanOptions = {
+  const options = {
     name: req.url ? (urlParse(req.url).pathname || '') : '',
     url: req.url,
     method: req.method,
-    traceContext: getFirstHeader(req, api.constants.TRACE_CONTEXT_HEADER_NAME),
+    traceContext: api.propagation.extract(key => req.headers[key]),
     skipFrames: 2
   };
   return api.runInRootSpan(options, (root) => {
     // Set response trace context.
-    const responseTraceContext = api.getResponseTraceContext(
-        options.traceContext || null, api.isRealSpan(root));
+    const responseTraceContext =
+        api.getResponseTraceContext(options.traceContext, api.isRealSpan(root));
     if (responseTraceContext) {
-      res.setHeader(
-          api.constants.TRACE_CONTEXT_HEADER_NAME, responseTraceContext);
+      api.propagation.inject(
+          (k, v) => res.setHeader(k, v), responseTraceContext);
     }
 
     if (!api.isRealSpan(root)) {

--- a/src/plugins/plugin-http2.ts
+++ b/src/plugins/plugin-http2.ts
@@ -97,8 +97,8 @@ function makeRequestTrace(
         api.labels.HTTP_METHOD_LABEL_KEY, extractMethodName(newHeaders));
     requestLifecycleSpan.addLabel(
         api.labels.HTTP_URL_LABEL_KEY, extractUrl(authority, newHeaders));
-    newHeaders[api.constants.TRACE_CONTEXT_HEADER_NAME] =
-        requestLifecycleSpan.getTraceContext();
+    api.propagation.inject(
+        (k, v) => newHeaders[k] = v, requestLifecycleSpan.getTraceContext());
     const stream: http2.ClientHttp2Stream = request.call(
         this, newHeaders, ...Array.prototype.slice.call(arguments, 1));
     api.wrapEmitter(stream);

--- a/src/plugins/plugin-koa.ts
+++ b/src/plugins/plugin-koa.ts
@@ -40,14 +40,6 @@ type CreateMiddlewareFn<T> = (api: PluginTypes.Tracer) => T;
 // propagateContext flag. The type of "next" differs between Koa 1 and 2.
 type GetNextFn<T> = (propagateContext: boolean) => T;
 
-function getFirstHeader(req: IncomingMessage, key: string): string|null {
-  let headerValue = req.headers[key] || null;
-  if (headerValue && typeof headerValue !== 'string') {
-    headerValue = headerValue[0];
-  }
-  return headerValue;
-}
-
 function startSpanForRequest<T>(
     api: PluginTypes.Tracer, ctx: KoaContext, getNext: GetNextFn<T>): T {
   const req = ctx.req;
@@ -57,16 +49,16 @@ function startSpanForRequest<T>(
     name: req.url ? (urlParse(req.url).pathname || '') : '',
     url: req.url,
     method: req.method,
-    traceContext: getFirstHeader(req, api.constants.TRACE_CONTEXT_HEADER_NAME),
+    traceContext: api.propagation.extract(key => req.headers[key]),
     skipFrames: 2
   };
   return api.runInRootSpan(options, root => {
     // Set response trace context.
-    const responseTraceContext = api.getResponseTraceContext(
-        options.traceContext || null, api.isRealSpan(root));
+    const responseTraceContext =
+        api.getResponseTraceContext(options.traceContext, api.isRealSpan(root));
     if (responseTraceContext) {
-      res.setHeader(
-          api.constants.TRACE_CONTEXT_HEADER_NAME, responseTraceContext);
+      api.propagation.inject(
+          (k, v) => res.setHeader(k, v), responseTraceContext);
     }
 
     if (!api.isRealSpan(root)) {

--- a/src/plugins/plugin-restify.ts
+++ b/src/plugins/plugin-restify.ts
@@ -52,7 +52,7 @@ function patchRestify(restify: Restify5, api: PluginTypes.Tracer) {
       name: req.path(),
       url: req.url,
       method: req.method,
-      traceContext: req.header(api.constants.TRACE_CONTEXT_HEADER_NAME),
+      traceContext: api.propagation.extract(key => req.header(key)),
       skipFrames: 1
     };
 
@@ -61,8 +61,8 @@ function patchRestify(restify: Restify5, api: PluginTypes.Tracer) {
       const responseTraceContext = api.getResponseTraceContext(
           options.traceContext, api.isRealSpan(rootSpan));
       if (responseTraceContext) {
-        res.header(
-            api.constants.TRACE_CONTEXT_HEADER_NAME, responseTraceContext);
+        api.propagation.inject(
+            (k, v) => res.setHeader(k, v), responseTraceContext);
       }
 
       if (!api.isRealSpan(rootSpan)) {

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -86,11 +86,11 @@ export abstract class BaseSpanData implements Span {
   }
 
   getTraceContext() {
-    return traceUtil.generateTraceContext({
+    return {
       traceId: this.trace.traceId.toString(),
       spanId: this.span.spanId.toString(),
       options: 1  // always traced
-    });
+    };
   }
 
   // tslint:disable-next-line:no-any
@@ -195,7 +195,7 @@ function createPhantomSpanData<T extends SpanType>(spanType: T): Span&
   return Object.freeze(Object.assign(
       {
         getTraceContext() {
-          return '';
+          return null;
         },
         // tslint:disable-next-line:no-any
         addLabel(key: string, value: any) {},

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -18,7 +18,7 @@ import {v1 as stackdriverPropagation} from '@opencensus/propagation-stackdriver'
 import * as path from 'path';
 
 import {cls, TraceCLSConfig} from './cls';
-import {TracePolicy} from './config';
+import {OpenCensusPropagation, TracePolicy} from './config';
 import {LEVELS, Logger} from './logger';
 import {StackdriverTracer} from './trace-api';
 import {pluginLoader, PluginLoaderConfig} from './trace-plugin-loader';
@@ -31,7 +31,8 @@ export type TopLevelConfig = {
   writerConfig: TraceWriterConfig;
   pluginLoaderConfig: PluginLoaderConfig;
   tracePolicyConfig: TracePolicyConfig;
-  overrides: {tracePolicy?: TracePolicy;};
+  overrides:
+      {tracePolicy?: TracePolicy; propagation?: OpenCensusPropagation;};
 }|{
   enabled: false;
 };
@@ -121,7 +122,8 @@ export class Tracing implements Component {
 
     const tracePolicy = this.config.overrides.tracePolicy ||
         new BuiltinTracePolicy(this.config.tracePolicyConfig);
-    const propagation = stackdriverPropagation;
+    const propagation =
+        this.config.overrides.propagation || stackdriverPropagation;
 
     const tracerComponents = {logger: this.logger, tracePolicy, propagation};
 

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {v1 as stackdriverPropagation} from '@opencensus/propagation-stackdriver';
 import * as path from 'path';
 
 import {cls, TraceCLSConfig} from './cls';
@@ -120,12 +121,13 @@ export class Tracing implements Component {
 
     const tracePolicy = this.config.overrides.tracePolicy ||
         new BuiltinTracePolicy(this.config.tracePolicyConfig);
+    const propagation = stackdriverPropagation;
+
+    const tracerComponents = {logger: this.logger, tracePolicy, propagation};
 
     this.traceAgent.enable(
-        this.config.pluginLoaderConfig.tracerConfig, tracePolicy, this.logger);
-    pluginLoader
-        .create(
-            this.config.pluginLoaderConfig, {logger: this.logger, tracePolicy})
+        this.config.pluginLoaderConfig.tracerConfig, tracerComponents);
+    pluginLoader.create(this.config.pluginLoaderConfig, tracerComponents)
         .activate();
 
     if (typeof this.config.writerConfig.projectId !== 'string' &&

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,6 +19,8 @@ import * as sourceMapSupport from 'source-map-support';
 const {hexToDec, decToHex}: {[key: string]: (input: string) => string} =
     require('hex2dec');
 
+export {hexToDec, decToHex};
+
 // This symbol must be exported (for now).
 // See: https://github.com/Microsoft/TypeScript/issues/20080
 export const kSingleton = Symbol();

--- a/test/plugins/common.ts
+++ b/test/plugins/common.ts
@@ -16,6 +16,7 @@
 'use strict';
 
 import '../override-gcp-metadata';
+import {v1 as stackdriverPropagation} from '@opencensus/propagation-stackdriver';
 import { cls, TraceCLS } from '../../src/cls';
 import { StackdriverTracer } from '../../src/trace-api';
 import { traceWriter } from '../../src/trace-writer';
@@ -65,7 +66,11 @@ shimmer.wrap(trace, 'start', function(original) {
   return function() {
     var result = original.apply(this, arguments);
     testTraceAgent = new StackdriverTracer('test');
-    testTraceAgent.enable(getBaseConfig(), alwaysTrace(), new TestLogger());
+    testTraceAgent.enable(getBaseConfig(), {
+      tracePolicy: alwaysTrace(),
+      logger: new TestLogger(),
+      propagation: stackdriverPropagation
+    });
     return result;
   };
 });

--- a/test/plugins/test-trace-grpc.ts
+++ b/test/plugins/test-trace-grpc.ts
@@ -475,7 +475,11 @@ describeInterop('grpc', fixture => {
   it('should support distributed trace context', function(done) {
     function makeLink(fn, meta, next) {
       return function() {
-        agent.runInRootSpan({ name: '', traceContext: `${COMMON_TRACE_ID}/0;o=1` }, function(span) {
+        agent.runInRootSpan({ name: '', traceContext: {
+          traceId: COMMON_TRACE_ID,
+          spanId: '0',
+          options: 1
+        }}, function(span) {
           assert.strictEqual(span.type, agent.spanTypes.ROOT);
           fn(client, grpc, meta, function() {
             span.endSpan();

--- a/test/test-config-plugins.ts
+++ b/test/test-config-plugins.ts
@@ -17,8 +17,8 @@
 import * as assert from 'assert';
 
 import {defaultConfig} from '../src/config';
-import {Logger} from '../src/logger';
-import {PluginLoader, PluginLoaderComponents, PluginLoaderConfig} from '../src/trace-plugin-loader';
+import {StackdriverTracerComponents} from '../src/trace-api';
+import {PluginLoader, PluginLoaderConfig} from '../src/trace-plugin-loader';
 
 import * as testTraceModule from './trace';
 
@@ -28,7 +28,7 @@ describe('Configuration: Plugins', () => {
 
   class ConfigTestPluginLoader extends PluginLoader {
     constructor(
-        config: PluginLoaderConfig, components: PluginLoaderComponents) {
+        config: PluginLoaderConfig, components: StackdriverTracerComponents) {
       super(config, components);
       plugins = config.plugins;
     }

--- a/test/test-index.ts
+++ b/test/test-index.ts
@@ -43,7 +43,10 @@ describe('index.js', function() {
     await disabledAgent.getProjectId().then(
         () => Promise.reject(new Error()), () => Promise.resolve());
     assert.strictEqual(disabledAgent.createChildSpan({ name: '' }).type, SpanType.UNTRACED);
-    assert.strictEqual(disabledAgent.getResponseTraceContext('', false), '');
+    assert.strictEqual(disabledAgent.getResponseTraceContext({
+      traceId: '1',
+      spanId: '1'
+    }, false), null);
     const fn = () => {};
     assert.strictEqual(disabledAgent.wrap(fn), fn);
     // TODO(kjin): Figure out how to test wrapEmitter

--- a/test/test-plugin-loader.ts
+++ b/test/test-plugin-loader.ts
@@ -17,11 +17,12 @@
 import * as assert from 'assert';
 import * as path from 'path';
 
+import {OpenCensusPropagation} from '../src/config';
 import {PluginLoader, PluginLoaderState, PluginWrapper} from '../src/trace-plugin-loader';
 import {alwaysTrace} from '../src/tracing-policy';
 
 import {TestLogger} from './logger';
-import {getBaseConfig} from './utils';
+import {getBaseConfig, NoPropagation} from './utils';
 
 export interface SimplePluginLoaderConfig {
   // An object which contains paths to files that should be loaded as plugins
@@ -41,7 +42,7 @@ describe('Trace Plugin Loader', () => {
   const makePluginLoader = (config: SimplePluginLoaderConfig) => {
     return new PluginLoader(
         Object.assign({tracerConfig: getBaseConfig()}, config),
-        {tracePolicy: alwaysTrace(), logger});
+        {tracePolicy: alwaysTrace(), logger, propagation: new NoPropagation()});
   };
 
   before(() => {

--- a/test/test-span-data.ts
+++ b/test/test-span-data.ts
@@ -158,11 +158,13 @@ describe('SpanData', () => {
       });
     });
 
-    it('exposes a method to provide serialized trace context', () => {
+    it('exposes a method to provide trace context', () => {
       const spanData = new CommonSpanData(trace, 'name', '0', 0);
-      assert.deepStrictEqual(
-          spanData.getTraceContext(),
-          `${spanData.trace.traceId}/${spanData.span.spanId};o=1`);
+      assert.deepStrictEqual(spanData.getTraceContext(), {
+        traceId: spanData.trace.traceId,
+        spanId: spanData.span.spanId,
+        options: 1
+      });
     });
 
     it('captures stack traces', () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -21,12 +21,12 @@ import * as fs from 'fs';
 import * as semver from 'semver';
 
 import {cls} from '../src/cls';
+import {OpenCensusPropagation} from '../src/config';
 import {SpanType} from '../src/constants';
 import {Span} from '../src/plugin-types';
 import {ChildSpanData, RootSpanData} from '../src/span-data';
 import {TraceSpan} from '../src/trace';
 import {StackdriverTracerConfig} from '../src/trace-api';
-import {alwaysTrace, TraceContextHeaderBehavior} from '../src/tracing-policy';
 
 /**
  * Constants
@@ -39,6 +39,16 @@ export const ASSERT_SPAN_TIME_TOLERANCE_MS = 5;
 
 export const SERVER_KEY = fs.readFileSync(`${__dirname}/fixtures/key.pem`);
 export const SERVER_CERT = fs.readFileSync(`${__dirname}/fixtures/cert.pem`);
+
+/**
+ * Misc. Implementations
+ */
+export class NoPropagation implements OpenCensusPropagation {
+  extract() {
+    return null;
+  }
+  inject() {}
+}
 
 /**
  * Helper Functions


### PR DESCRIPTION
Fixes #949, supercedes #950

With this change:
- Trace context header extraction and injection has been abstracted out of plugins and now exists in the `Tracer`.
- Its default underlying implementation is [`@opencensus/propagation-stackdriver`](https://www.npmjs.com/package/@opencensus/propagation-stackdriver) (behavior should match what the plugins do currently)
- APIs that make an assumption about trace context format have been __removed__ or __changed__. In particular (this is a __semver-major__ change):
  - `Tracer#traceContextUtils` no longer has methods for encoding and decoding trace context as a string.
  - The following APIs accept/return `TraceContext` objects instead of strings:
    - `Tracer#getResponseTraceContext`
    - `Tracer#createRootSpan`
    - `Span#getTraceContext`
- Users can now set the `propagation` field with an instance of `OpenCensusPropagation` to override the default implementation.