### PR TITLE
refactor: remove traceWriter singleton from span-data.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,11 +136,6 @@ function initConfig(userConfig: Forceable<Config>): Forceable<TopLevelConfig> {
       onUncaughtException: mergedConfig.onUncaughtException,
       bufferSize: mergedConfig.bufferSize,
       flushDelaySeconds: mergedConfig.flushDelaySeconds,
-      stackTraceLimit: mergedConfig.stackTraceLimit,
-      maximumLabelValueSize: Math.min(
-        mergedConfig.maximumLabelValueSize,
-        Constants.TRACE_SERVICE_LABEL_VALUE_LIMIT
-      ),
       serviceContext: {
         service: lastOf<string | undefined>(
           mergedConfig.serviceContext.service,
@@ -168,6 +163,11 @@ function initConfig(userConfig: Forceable<Config>): Forceable<TopLevelConfig> {
         ),
         spansPerTraceHardLimit: mergedConfig.spansPerTraceHardLimit,
         spansPerTraceSoftLimit: mergedConfig.spansPerTraceSoftLimit,
+        stackTraceLimit: mergedConfig.stackTraceLimit,
+        maximumLabelValueSize: Math.min(
+          mergedConfig.maximumLabelValueSize,
+          Constants.TRACE_SERVICE_LABEL_VALUE_LIMIT
+        ),
       },
     },
     tracePolicyConfig: {

--- a/src/trace-writer.ts
+++ b/src/trace-writer.ts
@@ -43,8 +43,6 @@ export interface TraceWriterConfig extends common.GoogleAuthOptions {
   onUncaughtException: string;
   bufferSize: number;
   flushDelaySeconds: number;
-  stackTraceLimit: number;
-  maximumLabelValueSize: number;
   serviceContext: { service?: string; version?: string; minorVersion?: string };
 }
 

--- a/test/test-config-max-label-size.ts
+++ b/test/test-config-max-label-size.ts
@@ -14,27 +14,22 @@
  * limitations under the License.
  */
 
-'use strict';
+import * as assert from 'assert';
 
 import { Constants } from '../src/constants';
-import { traceWriter } from '../src/trace-writer';
-import { FORCE_NEW } from '../src/util';
 
-var assert = require('assert');
-var trace = require('../..');
+import * as traceTestModule from './trace';
 
-describe('maximumLabelValueSize configuration', function() {
-  it('should not allow values above server maximum', function() {
-    trace.start({[FORCE_NEW]: true, maximumLabelValueSize: 1000000});
-    var valueMax = traceWriter.get().getConfig().maximumLabelValueSize;
+describe('maximumLabelValueSize configuration', () => {
+  it('should not allow values above server maximum', () => {
+    traceTestModule.start({ maximumLabelValueSize: 1000000 });
+    const valueMax = traceTestModule.get().getConfig().maximumLabelValueSize;
     assert.strictEqual(valueMax, Constants.TRACE_SERVICE_LABEL_VALUE_LIMIT);
   });
 
-  it('should not modify values below server maximum', function() {
-    trace.start({[FORCE_NEW]: true, maximumLabelValueSize: 10});
-    var valueMax = traceWriter.get().getConfig().maximumLabelValueSize;
+  it('should not modify values below server maximum', () => {
+    traceTestModule.start({ maximumLabelValueSize: 10 });
+    const valueMax = traceTestModule.get().getConfig().maximumLabelValueSize;
     assert.strictEqual(valueMax, 10);
   });
 });
-
-export default {};

--- a/test/test-config-priority.ts
+++ b/test/test-config-priority.ts
@@ -88,7 +88,10 @@ describe('should respect config load order', () => {
       traceTestModule.start({ logLevel: 3, stackTraceLimit: 2 });
       const config = getCapturedConfig();
       assert.strictEqual(config.logLevel, 2);
-      assert.strictEqual(config.writerConfig.stackTraceLimit, 2);
+      assert.strictEqual(
+        config.pluginLoaderConfig.tracerConfig.stackTraceLimit,
+        2
+      );
       assert.strictEqual(config.writerConfig.flushDelaySeconds, 31);
     });
   });

--- a/test/test-trace-writer.ts
+++ b/test/test-trace-writer.ts
@@ -90,8 +90,6 @@ describe('Trace Writer', () => {
     onUncaughtException: 'ignore',
     bufferSize: Infinity,
     flushDelaySeconds: 3600,
-    stackTraceLimit: 10,
-    maximumLabelValueSize: 1 << 16,
     serviceContext: {},
   };
   const logger = new TestLogger();

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -60,6 +60,8 @@ export function getBaseConfig(): StackdriverTracerConfig {
     rootSpanNameOverride: (name: string) => name,
     spansPerTraceSoftLimit: Infinity,
     spansPerTraceHardLimit: Infinity,
+    maximumLabelValueSize: 1 << 16,
+    stackTraceLimit: 10,
   };
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
     "test/test-cls.ts",
     "test/test-cls-ah.ts",
     "test/test-config-cls.ts",
+    "test/test-config-max-label-size.ts",
     "test/test-config-plugins.ts",
     "test/test-config-priority.ts",
     "test/test-default-ignore-ah-health.ts",


### PR DESCRIPTION
In preparation for a fix for #1025, this PR removes the references to the `traceWriter` singleton used in `SpanData` classes. It was used for two things:
* Publishing spans
* Getting span label limits

Now:
* Spans can be _enabled for publish_ by having a `TraceWriter` instance passed to them. This is so that in the future, we can have some spans that are "sampled" but not published, in order to address the issue mentioned above.
* Span label limits have been moved to `Tracer` config options instead, and passed in through the corresponding `SpanData` constructor.