### PR TITLE
fix!: always assign a trace ID to each request

### DIFF
--- a/src/cls.ts
+++ b/src/cls.ts
@@ -25,7 +25,7 @@ import { SingularCLS } from './cls/singular';
 import { SpanType } from './constants';
 import { Logger } from './logger';
 import { RootSpan } from './plugin-types';
-import { UNCORRELATED_ROOT_SPAN, UNTRACED_ROOT_SPAN } from './span-data';
+import { UNCORRELATED_ROOT_SPAN, DISABLED_ROOT_SPAN } from './span-data';
 import { Trace, TraceSpan } from './trace';
 import { Singleton } from './util';
 
@@ -104,7 +104,7 @@ export class TraceCLS implements CLS<RootContext> {
   private enabled = false;
 
   static UNCORRELATED: RootContext = UNCORRELATED_ROOT_SPAN;
-  static UNTRACED: RootContext = UNTRACED_ROOT_SPAN;
+  static DISABLED: RootContext = DISABLED_ROOT_SPAN;
 
   /**
    * Stack traces are captured when a root span is started. Because the stack
@@ -147,7 +147,7 @@ export class TraceCLS implements CLS<RootContext> {
     this.logger.info(
       `TraceCLS#constructor: Created [${config.mechanism}] CLS instance.`
     );
-    this.currentCLS = new NullCLS(TraceCLS.UNTRACED);
+    this.currentCLS = new NullCLS(TraceCLS.DISABLED);
     this.currentCLS.enable();
   }
 
@@ -171,7 +171,7 @@ export class TraceCLS implements CLS<RootContext> {
     if (this.enabled && this.CLSClass !== NullCLS) {
       this.logger.info('TraceCLS#disable: Disabling CLS.');
       this.currentCLS.disable();
-      this.currentCLS = new NullCLS(TraceCLS.UNTRACED);
+      this.currentCLS = new NullCLS(TraceCLS.DISABLED);
       this.currentCLS.enable();
     }
     this.enabled = false;

--- a/src/cls.ts
+++ b/src/cls.ts
@@ -38,7 +38,7 @@ export interface RealRootContext {
 }
 
 export interface PhantomRootContext {
-  readonly type: SpanType.UNCORRELATED | SpanType.UNTRACED;
+  readonly type: SpanType.UNCORRELATED | SpanType.UNSAMPLED | SpanType.DISABLED;
 }
 
 /**
@@ -156,9 +156,7 @@ export class TraceCLS implements CLS<RootContext> {
   }
 
   enable(): void {
-    // if this.CLSClass = NullCLS, the user specifically asked not to use
-    // any context propagation mechanism. So nothing should change.
-    if (!this.enabled && this.CLSClass !== NullCLS) {
+    if (!this.enabled) {
       this.logger.info('TraceCLS#enable: Enabling CLS.');
       this.currentCLS.disable();
       this.currentCLS = new this.CLSClass(TraceCLS.UNCORRELATED);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -57,17 +57,17 @@ export enum SpanType {
   UNCORRELATED = 'UNCORRELATED',
 
   /**
-   * This span object was created in circumstances where a trace span could not
-   * be created for one of the following reasons:
-   * (1) The Trace Agent is disabled, either explicitly or because a project ID
-   *     couldn't be determined.
-   * (2) The configured tracing policy disallows tracing for this request
-   *     (due to sampling restrictions, ignored URLs, etc.)
-   * (3) The current incoming request contains trace context headers that
-   *     explicitly disable local tracing for the request.
+   * This span object was created by a disabled Trace Agent, either explicitly
+   * or because a project ID couldn't be determined.
+   */
+  DISABLED = 'DISABLED',
+
+  /**
+   * This span object represents an unsampled request, and will not be
+   * published.
    * Getting a span object of this type should not be considered an error.
    */
-  UNTRACED = 'UNTRACED',
+  UNSAMPLED = 'UNSAMPLED',
 
   /**
    * This span object was created by StackdriverTracer#runInRootSpan, and

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -231,7 +231,7 @@ function createPhantomSpanData<T extends SpanType>(
  * child span.
  */
 class UntracedSpanData implements Span {
-  readonly type = SpanType.UNTRACED;
+  readonly type = SpanType.UNSAMPLED;
   protected readonly traceContext: TraceContext;
 
   constructor(traceId: string) {
@@ -279,7 +279,7 @@ export const UNCORRELATED_CHILD_SPAN = createPhantomSpanData(
  * A virtual trace span that indicates that a real child span couldn't be
  * created because the Trace Agent was disabled.
  */
-export const DISABLED_CHILD_SPAN = createPhantomSpanData(SpanType.UNTRACED);
+export const DISABLED_CHILD_SPAN = createPhantomSpanData(SpanType.DISABLED);
 
 /**
  * A virtual trace span that indicates that a real root span couldn't be

--- a/src/trace-api.ts
+++ b/src/trace-api.ts
@@ -390,9 +390,11 @@ export class StackdriverTracer implements Tracer {
         }] Created child span [${options.name}]`
       );
       return childContext;
-    } else if (rootSpan.type === SpanType.UNTRACED) {
+    } else if (rootSpan.type === SpanType.UNSAMPLED) {
       // "Untraced" child spans don't incur a memory penalty.
       return rootSpan.createChildSpan();
+    } else if (rootSpan.type === SpanType.DISABLED) {
+      return DISABLED_CHILD_SPAN;
     } else {
       // Context was lost.
       this.logger!.warn(

--- a/test/test-cls.ts
+++ b/test/test-cls.ts
@@ -242,7 +242,7 @@ describe('Continuation-Local Storage', () => {
       },
       {
         config: { mechanism: TraceCLSMechanism.NONE },
-        expectedDefaultType: SpanType.UNTRACED,
+        expectedDefaultType: SpanType.UNCORRELATED,
       },
     ];
     if (asyncAwaitSupported) {
@@ -273,7 +273,7 @@ describe('Continuation-Local Storage', () => {
         it(`when disabled, doesn't throw and has reasonable default values`, () => {
           c.disable();
           assert.ok(!c.isEnabled());
-          assert.ok(c.getContext().type, SpanType.UNTRACED);
+          assert.ok(c.getContext().type, SpanType.UNSAMPLED);
           assert.ok(c.runWithContext(() => 'hi', TraceCLS.UNCORRELATED), 'hi');
           const fn = () => {};
           assert.strictEqual(c.bindWithCurrentContext(fn), fn);

--- a/test/test-default-ignore-ah-health.ts
+++ b/test/test-default-ignore-ah-health.ts
@@ -22,7 +22,7 @@ describe('Trace API', () => {
   it('should ignore /_ah/health traces by default', () => {
     const traceApi = trace.start();
     traceApi.runInRootSpan({ name: 'root', url: '/_ah/health' }, rootSpan => {
-      assert.strictEqual(rootSpan.type, traceApi.spanTypes.UNTRACED);
+      assert.strictEqual(rootSpan.type, traceApi.spanTypes.UNSAMPLED);
     });
   });
 });

--- a/test/test-index.ts
+++ b/test/test-index.ts
@@ -31,18 +31,18 @@ describe('index.js', function() {
     assert.ok(!disabledAgent.isActive()); // ensure it's disabled first
     let ranInRootSpan = false;
     disabledAgent.runInRootSpan({ name: '' }, (span) => {
-      assert.strictEqual(span.type, SpanType.UNTRACED);
+      assert.strictEqual(span.type, SpanType.DISABLED);
       ranInRootSpan = true;
     });
     assert.ok(ranInRootSpan);
     assert.strictEqual(disabledAgent.enhancedDatabaseReportingEnabled(), false);
     assert.strictEqual(disabledAgent.getCurrentContextId(), null);
     assert.strictEqual(disabledAgent.getWriterProjectId(), null);
-    assert.strictEqual(disabledAgent.getCurrentRootSpan().type, SpanType.UNTRACED);
+    assert.strictEqual(disabledAgent.getCurrentRootSpan().type, SpanType.DISABLED);
     // getting project ID should reject.
     await disabledAgent.getProjectId().then(
         () => Promise.reject(new Error()), () => Promise.resolve());
-    assert.strictEqual(disabledAgent.createChildSpan({ name: '' }).type, SpanType.UNTRACED);
+    assert.strictEqual(disabledAgent.createChildSpan({ name: '' }).type, SpanType.DISABLED);
     assert.strictEqual(disabledAgent.getResponseTraceContext({
       traceId: '1',
       spanId: '1'

--- a/test/test-trace-api-none-cls.ts
+++ b/test/test-trace-api-none-cls.ts
@@ -74,7 +74,7 @@ describe('Custom Trace API with CLS disabled', () => {
       traceApi.runInRootSpan({ name: 'root' }, identity)
     );
     const child = traceApi.createChildSpan({ name: 'child' });
-    assert.strictEqual(child.type, SpanType.UNTRACED);
+    assert.strictEqual(child.type, SpanType.UNCORRELATED);
     child.endSpan();
     root.endSpan();
   });

--- a/test/test-trace-api.ts
+++ b/test/test-trace-api.ts
@@ -220,7 +220,7 @@ describe('Trace Interface', () => {
     it('should return a context ID even if in an untraced request', () => {
       const traceAPI = createTraceAgent({}, { tracePolicy: neverTrace() });
       traceAPI.runInRootSpan({ name: '' }, rootSpan => {
-        assert.strictEqual(rootSpan.type, SpanType.UNTRACED);
+        assert.strictEqual(rootSpan.type, SpanType.UNSAMPLED);
         assert.notStrictEqual(traceAPI.getCurrentContextId(), null);
         assert.ok(rootSpan.getTraceContext());
         assert.strictEqual(
@@ -262,7 +262,7 @@ describe('Trace Interface', () => {
         };
         const beforeRootSpan = Date.now();
         traceAPI.runInRootSpan(rootSpanOptions, rootSpan => {
-          assert.strictEqual(rootSpan.type, SpanType.UNTRACED);
+          assert.strictEqual(rootSpan.type, SpanType.UNSAMPLED);
           rootSpan.endSpan();
         });
         const afterRootSpan = Date.now();
@@ -284,7 +284,7 @@ describe('Trace Interface', () => {
       {
         const rootSpanOptions = { name: 'root' };
         traceAPI.runInRootSpan(rootSpanOptions, rootSpan => {
-          assert.strictEqual(rootSpan.type, SpanType.UNTRACED);
+          assert.strictEqual(rootSpan.type, SpanType.UNSAMPLED);
           rootSpan.endSpan();
         });
         assert.ok(tracePolicy.capturedShouldTraceParam);

--- a/test/test-trace-api.ts
+++ b/test/test-trace-api.ts
@@ -32,7 +32,7 @@ import {
   StackdriverTracerConfig,
 } from '../src/trace-api';
 import { traceWriter } from '../src/trace-writer';
-import { alwaysTrace } from '../src/tracing-policy';
+import { alwaysTrace, neverTrace } from '../src/tracing-policy';
 import { FORCE_NEW, TraceContext } from '../src/util';
 
 import { TestLogger } from './logger';
@@ -200,18 +200,35 @@ describe('Trace Interface', () => {
       });
     });
 
-    it('should return null context id when one does not exist', () => {
+    it('should return null context ID when one does not exist', () => {
       const traceAPI = createTraceAgent();
       assert.strictEqual(traceAPI.getCurrentContextId(), null);
     });
 
-    it('should return the appropriate trace id', () => {
+    it('should return the appropriate context ID', () => {
       const traceAPI = createTraceAgent();
       traceAPI.runInRootSpan({ name: 'root' }, rootSpan => {
         const id = traceAPI.getCurrentContextId();
+        assert.ok(rootSpan.getTraceContext());
+        assert.strictEqual(id, rootSpan.getTraceContext()!.traceId);
         rootSpan.endSpan();
         // getOneTrace asserts that there is exactly one trace.
         testTraceModule.getOneTrace(trace => trace.traceId === id);
+      });
+    });
+
+    it('should return a context ID even if in an untraced request', () => {
+      const traceAPI = createTraceAgent({}, { tracePolicy: neverTrace() });
+      traceAPI.runInRootSpan({ name: '' }, rootSpan => {
+        assert.strictEqual(rootSpan.type, SpanType.UNTRACED);
+        assert.notStrictEqual(traceAPI.getCurrentContextId(), null);
+        assert.ok(rootSpan.getTraceContext());
+        assert.strictEqual(
+          traceAPI.getCurrentContextId(),
+          rootSpan.getTraceContext()!.traceId
+        );
+        assert.ok(rootSpan.createChildSpan().getTraceContext());
+        assert.ok(traceAPI.createChildSpan().getTraceContext());
       });
     });
 


### PR DESCRIPTION
Fixes #1025

We already store untraced requests (via a single object representing ALL untraced requests) in CLS, this changes it so that these objects also have a trace ID (and span ID, though not sure if it is useful).