### PR TITLE
doc: remove references to old versions of Node in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This module provides automatic tracing for Node.js applications with Stackdriver
 
 ## Usage
 
-The Trace Agent supports Node 6+.
+The Trace Agent supports Node 8+.
 
 > **Note**: Using the Trace Agent requires a Google Cloud Project with the [Stackdriver Trace API enabled](https://console.cloud.google.com/flows/enableapi?apiid=cloudtrace) and associated credentials. These values are auto-detected if the application is running on Google Cloud Platform. If your application is not running on GCP, you will need to specify the project ID and credentials either through the configuration object, or with environment variables. See [Setting Up Stackdriver Trace for Node.js][setting-up-stackdriver-trace] for more details.
 
@@ -54,8 +54,6 @@ app.get('/', async () => {
   // ...
 });
 ```
-
-> **Note**: If your source code contains untranspiled [`async/await`][async-await-docs] (introduced in Node 7.6), please see [this section](#tracing-with-async/await) on enabling experimental tracing for `async` functions.
 
 ## What gets traced
 
@@ -146,21 +144,18 @@ A fully detailed overview of the `Tracer` object is available [here](doc/trace-a
 
 ## How does automatic tracing work?
 
-The Trace Agent automatically patches well-known modules to insert calls to functions that start, label, and end spans to measure latency of RPCs (such as mysql, redis, etc.) and incoming requests (such as express, hapi, etc.). As each RPC is typically performed on behalf of an incoming request, we must make sure that this association is accurately reflected in span data. To provide a uniform, generalized way of keeping track of which RPC belongs to which incoming request, we rely on the following mechanisms to keep track of the "trace context" across asynchronous boundaries:
-  * [`continuation-local-storage`][continuation-local-storage] (which relies on [`async-listener`][async-listener]) in Node 6
-  * [`async_hooks`][async-hooks] in Node 8+
+The Trace Agent automatically patches well-known modules to insert calls to functions that start, label, and end spans to measure latency of RPCs (such as mysql, redis, etc.) and incoming requests (such as express, hapi, etc.). As each RPC is typically performed on behalf of an incoming request, we must make sure that this association is accurately reflected in span data. To provide a uniform, generalized way of keeping track of which RPC belongs to which incoming request, we rely on [`async_hooks`][async-hooks] to keep track of the "trace context" across asynchronous boundaries.
 
-These mechanisms work great in most cases. However, they do have some limitations that can prevent us from being able to properly propagate trace context:
+`async_hooks` works well in most cases. However, it does have some limitations that can prevent us from being able to properly propagate trace context:
 
 * It is possible that a module does its own queuing of callback functions – effectively merging asynchronous execution contexts. For example, one may write an http request buffering library that queues requests and then performs them in a batch in one shot. In such a case, when all the callbacks fire, they will execute in the context which flushed the queue instead of the context which added the callbacks to the queue. This problem is called the pooling problem or the [user-space queuing problem][queuing-problem], and is a fundamental limitation of JavaScript. If your application uses such code, you will notice that RPCs from many requests are showing up under a single trace, or that certain portions of your outbound RPCs do not get traced. In such cases we try to work around the problem through monkey patching, or by working with the library authors to fix the code to properly propagate context. However, finding problematic code is not always trivial.
-* If your application uses untranspiled `async` functions, you must use Node 8+. (Untranspiled `async` functions are supported from Node 7.6 onward, but we do not support tracing these functions in Node 7.)
-* The Node.js `async_hooks` API has [issues tracking context](https://github.com/nodejs/node/issues/26064) around `await`-ed "thenables" (rather than real promises). Requests originating from the body of a `then` implementation in such a user-space "thenable" may not get traced. This is largely an unconventional case but is present in the `knex` module, which monkeypatches the Bluebird Promise's prototype to make database calls. __If you are using `knex` (esp. the `raw` function), see [#946](https://github.com/googleapis/cloud-trace-nodejs/issues/946) for more details on whether you are affected, as well as a suggested workaround.__
+* The `async_hooks` API has [issues tracking context](https://github.com/nodejs/node/issues/26064) around `await`-ed "thenables" (rather than real promises). Requests originating from the body of a `then` implementation in such a user-space "thenable" may not get traced. This is largely an unconventional case but is present in the `knex` module, which monkeypatches the Bluebird Promise's prototype to make database calls. __If you are using `knex` (esp. the `raw` function), see [#946](https://github.com/googleapis/cloud-trace-nodejs/issues/946) for more details on whether you are affected, as well as a suggested workaround.__
 
 ### Tracing bundled or webpacked server code.
 
 *unsupported*
 
-The way we trace modules does not support bundled server code. Bundlers like webpack or @zeit/ncc will not work.
+The Trace Agent does not support bundled server code, so bundlers like webpack or @zeit/ncc will not work.
 
 ## Contributing changes
 
@@ -174,7 +169,6 @@ The way we trace modules does not support bundled server code. Bundlers like web
 [async-hooks]: https://nodejs.org/api/async_hooks.html
 [async-listener]: https://www.npmjs.com/package/async-listener
 [cloud-console]: https://console.cloud.google.com
-[continuation-local-storage]: https://www.npmjs.com/package/continuation-local-storage
 [codecov-image]: https://codecov.io/gh/googleapis/cloud-trace-nodejs/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/googleapis/cloud-trace-nodejs
 [david-dev-image]: https://david-dm.org/googleapis/cloud-trace-nodejs/dev-status.svg


### PR DESCRIPTION
We no longer support any versions of Node where `async_hooks` isn't present.