### PR TITLE
refactor: use the shared prettier config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+node_modules/*
+samples/node_modules/*
+src/**/doc/*

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+---
+bracketSpacing: false
+printWidth: 80
+semi: true
+singleQuote: true
+tabWidth: 2
+trailingComma: es5
+useTabs: false

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "get-plugin-types": "npm run script get-plugin-types",
     "coverage": "npm run script run-unit-tests-with-coverage report-coverage",
     "check": "gts check",
+    "lint": "gts check",
     "clean": "rimraf build/src",
     "compile-all": "npm run script compile-auto",
     "compile-strict": "npm run script compile-auto-strict",

--- a/src/cls.ts
+++ b/src/cls.ts
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 import * as semver from 'semver';
 
-import { AsyncHooksCLS } from './cls/async-hooks';
-import { AsyncListenerCLS } from './cls/async-listener';
-import { CLS, Func } from './cls/base';
-import { NullCLS } from './cls/null';
-import { SingularCLS } from './cls/singular';
-import { SpanType } from './constants';
-import { Logger } from './logger';
-import { RootSpan } from './plugin-types';
-import { UNCORRELATED_ROOT_SPAN, DISABLED_ROOT_SPAN } from './span-data';
-import { Trace, TraceSpan } from './trace';
-import { Singleton } from './util';
+import {AsyncHooksCLS} from './cls/async-hooks';
+import {AsyncListenerCLS} from './cls/async-listener';
+import {CLS, Func} from './cls/base';
+import {NullCLS} from './cls/null';
+import {SingularCLS} from './cls/singular';
+import {SpanType} from './constants';
+import {Logger} from './logger';
+import {RootSpan} from './plugin-types';
+import {UNCORRELATED_ROOT_SPAN, DISABLED_ROOT_SPAN} from './span-data';
+import {Trace, TraceSpan} from './trace';
+import {Singleton} from './util';
 
 const asyncHooksAvailable = semver.satisfies(process.version, '>=8');
 

--- a/src/cls/async-hooks.ts
+++ b/src/cls/async-hooks.ts
@@ -17,10 +17,10 @@
 // This file calls require('async_hooks') in the AsyncHooksCLS constructor,
 // rather than upon module load.
 import * as asyncHooksModule from 'async_hooks';
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 import * as shimmer from 'shimmer';
 
-import { CLS, Func } from './base';
+import {CLS, Func} from './base';
 
 type AsyncHooksModule = typeof asyncHooksModule;
 
@@ -35,7 +35,7 @@ const EVENT_EMITTER_METHODS: Array<keyof EventEmitter> = [
 // A symbol used to check if a method has been wrapped for context.
 const WRAPPED = Symbol('@google-cloud/trace-agent:AsyncHooksCLS:WRAPPED');
 
-type ContextWrapped<T> = T & { [WRAPPED]?: boolean };
+type ContextWrapped<T> = T & {[WRAPPED]?: boolean};
 
 /**
  * An implementation of continuation-local storage on top of the async_hooks
@@ -46,7 +46,7 @@ export class AsyncHooksCLS<Context extends {}> implements CLS<Context> {
   private ah: AsyncHooksModule;
 
   /** A map of AsyncResource IDs to Context objects. */
-  private contexts: { [id: number]: Context } = {};
+  private contexts: {[id: number]: Context} = {};
   /** The AsyncHook that proactively populates entries in this.contexts. */
   private hook: asyncHooksModule.AsyncHook;
   /** Whether this instance is enabled. */

--- a/src/cls/async-listener.ts
+++ b/src/cls/async-listener.ts
@@ -17,9 +17,9 @@
 // This module requires continuation-local-storage in the AsyncListenerCLS
 // constructor, rather than upon module load.
 import * as clsModule from 'continuation-local-storage';
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 
-import { CLS, Func } from './base';
+import {CLS, Func} from './base';
 
 type CLSModule = typeof clsModule;
 

--- a/src/cls/base.ts
+++ b/src/cls/base.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 
 // tslint:disable-next-line:no-any
 export type Func<T = void> = (...args: any[]) => T;

--- a/src/cls/null.ts
+++ b/src/cls/null.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 
-import { CLS, Func } from './base';
+import {CLS, Func} from './base';
 
 /**
  * A trivial implementation of continuation-local storage where context takes on

--- a/src/cls/singular.ts
+++ b/src/cls/singular.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 
-import { CLS, Func } from './base';
+import {CLS, Func} from './base';
 
 /**
  * A trivial implementation of continuation-local storage where everything is

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,7 +47,7 @@ export interface RequestDetails {
   /**
    * The parsed trace context, if it exists.
    */
-  traceContext: { traceId: string; spanId: string; options: number } | null;
+  traceContext: {traceId: string; spanId: string; options: number} | null;
   /**
    * The original options object used to create the root span that corresponds
    * to this request.
@@ -166,7 +166,7 @@ export interface Config {
    * value. Disabling any of the default plugins may cause unwanted behavior,
    * so use caution.
    */
-  plugins?: { [pluginName: string]: string };
+  plugins?: {[pluginName: string]: string};
 
   /**
    * The max number of frames to include on traces; pass a value of 0 to
@@ -281,7 +281,7 @@ export interface Config {
    * The contents of a key file. If this field is set, its contents will be
    * used for authentication instead of your application default credentials.
    */
-  credentials?: { client_email?: string; private_key?: string };
+  credentials?: {client_email?: string; private_key?: string};
 
   /**
    * A path to a key file relative to the current working directory. If this

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,18 +19,18 @@ const filesLoadedBeforeTrace = Object.keys(require.cache);
 // This file's top-level imports must not transitively depend on modules that
 // do I/O, or continuation-local-storage will not work.
 import * as semver from 'semver';
-import { Config, defaultConfig, TracePolicy } from './config';
+import {Config, defaultConfig, TracePolicy} from './config';
 import * as extend from 'extend';
 import * as path from 'path';
 import * as PluginTypes from './plugin-types';
-import { Tracing, TopLevelConfig } from './tracing';
-import { FORCE_NEW, Forceable, lastOf } from './util';
-import { Constants } from './constants';
-import { TraceCLSMechanism } from './cls';
-import { StackdriverTracer } from './trace-api';
-import { TraceContextHeaderBehavior } from './tracing-policy';
+import {Tracing, TopLevelConfig} from './tracing';
+import {FORCE_NEW, Forceable, lastOf} from './util';
+import {Constants} from './constants';
+import {TraceCLSMechanism} from './cls';
+import {StackdriverTracer} from './trace-api';
+import {TraceContextHeaderBehavior} from './tracing-policy';
 
-export { Config, PluginTypes };
+export {Config, PluginTypes};
 
 let traceAgent: StackdriverTracer;
 
@@ -164,7 +164,7 @@ function initConfig(userConfig: Forceable<Config>): TopLevelConfig {
     },
     pluginLoaderConfig: {
       [FORCE_NEW]: forceNew,
-      plugins: { ...mergedConfig.plugins },
+      plugins: {...mergedConfig.plugins},
       tracerConfig: {
         enhancedDatabaseReporting: mergedConfig.enhancedDatabaseReporting,
         rootSpanNameOverride: getInternalRootSpanNameOverride(

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -15,7 +15,7 @@
  */
 
 import * as consoleLogLevel from 'console-log-level';
-import { defaultConfig } from './config';
+import {defaultConfig} from './config';
 
 export type ConsoleLogLevel = 'error' | 'warn' | 'info' | 'debug';
 export type LogLevel = 'silent' | ConsoleLogLevel;

--- a/src/plugin-types.ts
+++ b/src/plugin-types.ts
@@ -17,14 +17,14 @@
 // This file only describes public-facing interfaces.
 // tslint:disable:no-any
 
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 
-import { Constants, SpanType } from './constants';
-import { StackdriverTracerConfig } from './trace-api';
-import { TraceLabels } from './trace-labels';
-import { TraceContext } from './util';
+import {Constants, SpanType} from './constants';
+import {StackdriverTracerConfig} from './trace-api';
+import {TraceLabels} from './trace-labels';
+import {TraceContext} from './util';
 
-export { TraceContext };
+export {TraceContext};
 
 export type Func<T> = (...args: any[]) => T;
 

--- a/src/plugins/plugin-bluebird.ts
+++ b/src/plugins/plugin-bluebird.ts
@@ -16,11 +16,11 @@
 
 import * as shimmer from 'shimmer';
 
-import { PluginTypes } from '..';
+import {PluginTypes} from '..';
 
-import { bluebird_3 } from './types';
+import {bluebird_3} from './types';
 
-type BluebirdModule = typeof bluebird_3 & { prototype: { _then: Function } };
+type BluebirdModule = typeof bluebird_3 & {prototype: {_then: Function}};
 
 const plugin: PluginTypes.Plugin = [
   {

--- a/src/plugins/plugin-connect.ts
+++ b/src/plugins/plugin-connect.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import { IncomingMessage, ServerResponse } from 'http';
-import { parse as urlParse } from 'url';
+import {IncomingMessage, ServerResponse} from 'http';
+import {parse as urlParse} from 'url';
 
-import { PluginTypes } from '..';
+import {PluginTypes} from '..';
 
-import { connect_3 } from './types';
+import {connect_3} from './types';
 
 type Connect3 = typeof connect_3;
 // Connect docs note that routed requests have an originalUrl property.
 // https://github.com/senchalabs/connect/tree/3.6.5#appuseroute-fn
-type Request = IncomingMessage & { originalUrl?: string };
+type Request = IncomingMessage & {originalUrl?: string};
 
 const SUPPORTED_VERSIONS = '3.x';
 

--- a/src/plugins/plugin-express.ts
+++ b/src/plugins/plugin-express.ts
@@ -17,12 +17,12 @@
 import * as httpMethods from 'methods';
 import * as shimmer from 'shimmer';
 
-import { PluginTypes } from '..';
+import {PluginTypes} from '..';
 
-import { express_4 } from './types';
+import {express_4} from './types';
 
 // application is an undocumented member of the express object.
-type Express4Module = typeof express_4 & { application: express_4.Application };
+type Express4Module = typeof express_4 & {application: express_4.Application};
 
 const methods: Array<keyof express_4.Application> = (httpMethods as Array<
   keyof express_4.Application

--- a/src/plugins/plugin-grpc.ts
+++ b/src/plugins/plugin-grpc.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 import * as grpcModule from 'grpc'; // for types only.
 import {
   Client,
@@ -42,7 +42,7 @@ type Metadata = grpcModule.Metadata & {
 type MetadataModule = typeof grpcModule.Metadata;
 // Type of makeClientConstructor as exported from client.js
 type MakeClientConstructorFunction = (
-  methods: { [key: string]: { originalName?: string } },
+  methods: {[key: string]: {originalName?: string}},
   serviceName: string,
   classOptions: never
 ) => typeof Client;
@@ -197,7 +197,7 @@ function patchClient(client: ClientModule, api: Tracer) {
     // ReturnType<ClientMethod<S, T>>
     function clientMethodTrace(this: Client): EventEmitter {
       // The span name will be of form "grpc:/[Service]/[MethodName]".
-      const span = api.createChildSpan({ name: 'grpc:' + method.path });
+      const span = api.createChildSpan({name: 'grpc:' + method.path});
       if (!api.isRealSpan(span)) {
         // Span couldn't be created, either by policy or because a root span
         // doesn't exist.

--- a/src/plugins/plugin-hapi.ts
+++ b/src/plugins/plugin-hapi.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { IncomingMessage, ServerResponse } from 'http';
+import {IncomingMessage, ServerResponse} from 'http';
 import * as shimmer from 'shimmer';
-import { parse as urlParse } from 'url';
+import {parse as urlParse} from 'url';
 
-import { PluginTypes } from '..';
+import {PluginTypes} from '..';
 
-import { hapi_16, hapi_17 } from './types';
+import {hapi_16, hapi_17} from './types';
 
 // Used when patching Hapi 17.
 const ORIGINAL = Symbol();
@@ -147,7 +147,7 @@ const plugin: PluginTypes.Plugin = [
             return origExecute.apply(this, arguments);
           });
         },
-        { [ORIGINAL]: origExecute }
+        {[ORIGINAL]: origExecute}
       );
     },
     // Request is a class name.
@@ -157,6 +157,6 @@ const plugin: PluginTypes.Plugin = [
         Request.prototype._execute = Request.prototype._execute[ORIGINAL]!;
       }
     },
-  } as PluginTypes.Monkeypatch<{ prototype: Hapi17Request }>,
+  } as PluginTypes.Monkeypatch<{prototype: Hapi17Request}>,
 ];
 export = plugin;

--- a/src/plugins/plugin-http.ts
+++ b/src/plugins/plugin-http.ts
@@ -15,14 +15,14 @@
  */
 
 import * as httpModule from 'http';
-import { Agent, ClientRequest, ClientRequestArgs, get, request } from 'http';
+import {Agent, ClientRequest, ClientRequestArgs, get, request} from 'http';
 import * as httpsModule from 'https';
 import * as is from 'is';
 import * as semver from 'semver';
 import * as shimmer from 'shimmer';
 import * as url from 'url';
 
-import { Plugin, Tracer } from '../plugin-types';
+import {Plugin, Tracer} from '../plugin-types';
 
 type HttpModule = typeof httpModule;
 type HttpsModule = typeof httpsModule;
@@ -69,7 +69,7 @@ function extractUrl(
     // pathname only exists on a URL object.
     path = options.pathname || '/';
   } else {
-    const agent = options._defaultAgent as Agent & { protocol?: string };
+    const agent = options._defaultAgent as Agent & {protocol?: string};
     if (agent) {
       fallbackProtocol = agent.protocol || fallbackProtocol;
     }
@@ -123,7 +123,7 @@ function makeRequestTrace(
       options = url.parse(options);
     }
 
-    const span = api.createChildSpan({ name: getSpanName(options) });
+    const span = api.createChildSpan({name: getSpanName(options)});
     if (!api.isRealSpan(span)) {
       return request(options, callback);
     }

--- a/src/plugins/plugin-http2.ts
+++ b/src/plugins/plugin-http2.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 // This is imported only for types. Generated .js file should NOT load 'http2'.
 // `http2` must be used only in type annotations, not in expressions.
 import * as http2 from 'http2';
 import * as shimmer from 'shimmer';
-import { URL } from 'url';
+import {URL} from 'url';
 
-import { Tracer } from '../plugin-types';
+import {Tracer} from '../plugin-types';
 
 type Http2Module = typeof http2;
 

--- a/src/plugins/plugin-koa.ts
+++ b/src/plugins/plugin-koa.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { IncomingMessage, ServerResponse } from 'http';
+import {IncomingMessage, ServerResponse} from 'http';
 import * as shimmer from 'shimmer';
-import { parse as urlParse } from 'url';
+import {parse as urlParse} from 'url';
 
-import { PluginTypes } from '..';
+import {PluginTypes} from '..';
 
-import { koa_1, koa_2 } from './types';
+import {koa_1, koa_2} from './types';
 
 type Koa1Module = typeof koa_1;
 type Koa2Module = typeof koa_2;
@@ -32,7 +32,7 @@ type KoaContext = (koa_1.Context | koa_2.Context) & {
 interface KoaModule<T> {
   // TypeScript isn't expressive enough, but KoaModule#use should return `this`.
   // tslint:disable-next-line:no-any
-  readonly prototype: { use: (m: T) => any };
+  readonly prototype: {use: (m: T) => any};
 }
 
 // Function signature for createMiddleware[2x]

--- a/src/plugins/plugin-pg.ts
+++ b/src/plugins/plugin-pg.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 import * as shimmer from 'shimmer';
 
-import { Patch, Plugin, Span, Tracer } from '../plugin-types';
+import {Patch, Plugin, Span, Tracer} from '../plugin-types';
 
-import { pg_6, pg_7 } from './types';
+import {pg_6, pg_7} from './types';
 
 // TS: Client#query also accepts a callback as a last argument, but TS cannot
 // detect this as it's a dependent type. So we don't specify it here.
@@ -28,7 +28,7 @@ type ClientQueryArguments =
   | [string]
   | [string, {}];
 type PG7QueryReturnValue =
-  | (pg_7.QueryConfig & ({ submit: Function } & EventEmitter) | pg_7.Query)
+  | (pg_7.QueryConfig & ({submit: Function} & EventEmitter) | pg_7.Query)
   | Promise<pg_7.QueryResult>;
 type Callback<T> = (err: Error | null, res?: T) => void;
 
@@ -98,7 +98,7 @@ class PostgresPatchUtility {
 
   patchSubmittable(pgQuery: Submittable, span: Span): Submittable {
     let spanEnded = false;
-    const { maybePopulateLabelsFromOutputs } = this;
+    const {maybePopulateLabelsFromOutputs} = this;
     if (pgQuery.handleError) {
       shimmer.wrap(pgQuery, 'handleError', origCallback => {
         // Elements of args are not individually accessed.
@@ -199,7 +199,7 @@ const plugin: Plugin = [
           ...args: ClientQueryArguments
         ) {
           if (args.length >= 1) {
-            const span = api.createChildSpan({ name: 'pg-query' });
+            const span = api.createChildSpan({name: 'pg-query'});
             if (!api.isRealSpan(span)) {
               return query.apply(this, args);
             }
@@ -238,7 +238,7 @@ const plugin: Plugin = [
       const pgPatch = new PostgresPatchUtility(api);
       shimmer.wrap(Client.prototype, 'query', query => {
         return function query_trace(this: pg_7.Client) {
-          const span = api.createChildSpan({ name: 'pg-query' });
+          const span = api.createChildSpan({name: 'pg-query'});
           if (!api.isRealSpan(span)) {
             return query.apply(this, arguments);
           }

--- a/src/plugins/plugin-restify.ts
+++ b/src/plugins/plugin-restify.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import { ServerResponse } from 'http';
+import {ServerResponse} from 'http';
 import * as shimmer from 'shimmer';
-import { parse as urlParse } from 'url';
+import {parse as urlParse} from 'url';
 
-import { PluginTypes } from '..';
+import {PluginTypes} from '..';
 
-import { restify_5 } from './types';
+import {restify_5} from './types';
 
 type Restify5 = typeof restify_5;
-type Request = restify_5.Request & { route?: { path: string | RegExp } };
+type Request = restify_5.Request & {route?: {path: string | RegExp}};
 type Response = restify_5.Response;
 type Next = restify_5.Next;
 type CreateServerFn = (options?: restify_5.ServerOptions) => restify_5.Server;

--- a/src/span-data.ts
+++ b/src/span-data.ts
@@ -17,11 +17,11 @@
 import * as crypto from 'crypto';
 import * as util from 'util';
 
-import { Constants, SpanType } from './constants';
-import { RootSpan, Span, SpanOptions, TraceContext } from './plugin-types';
-import { SpanKind, Trace, TraceSpan } from './trace';
-import { TraceLabels } from './trace-labels';
-import { traceWriter } from './trace-writer';
+import {Constants, SpanType} from './constants';
+import {RootSpan, Span, SpanOptions, TraceContext} from './plugin-types';
+import {SpanKind, Trace, TraceSpan} from './trace';
+import {TraceLabels} from './trace-labels';
+import {traceWriter} from './trace-writer';
 import * as traceUtil from './util';
 
 // Use 6 bytes of randomness only as JS numbers are doubles not 64-bit ints.
@@ -88,7 +88,7 @@ export abstract class BaseSpanData implements Span {
       this.span.labels[
         TraceLabels.STACK_TRACE_DETAILS_KEY
       ] = traceUtil.truncate(
-        JSON.stringify({ stack_frame: stackFrames }),
+        JSON.stringify({stack_frame: stackFrames}),
         Constants.TRACE_SERVICE_LABEL_VALUE_LIMIT
       );
     }
@@ -142,7 +142,7 @@ export class RootSpanData extends BaseSpanData implements RootSpan {
   }
 
   createChildSpan(options?: SpanOptions): Span {
-    options = options || { name: '' };
+    options = options || {name: ''};
     const skipFrames = options.skipFrames ? options.skipFrames + 1 : 1;
     const child = new ChildSpanData(
       this.trace /* Trace object */,
@@ -210,7 +210,7 @@ export class ChildSpanData extends BaseSpanData {
 // Helper function to generate static virtual trace spans.
 function createPhantomSpanData<T extends SpanType>(
   spanType: T
-): Span & { readonly type: T } {
+): Span & {readonly type: T} {
   return Object.freeze(
     Object.assign(
       {
@@ -221,7 +221,7 @@ function createPhantomSpanData<T extends SpanType>(
         addLabel(key: string, value: any) {},
         endSpan() {},
       },
-      { type: spanType }
+      {type: spanType}
     )
   );
 }

--- a/src/trace-api.ts
+++ b/src/trace-api.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 import * as uuid from 'uuid';
 
-import { cls, RootContext } from './cls';
-import { OpenCensusPropagation, TracePolicy } from './config';
-import { Constants, SpanType } from './constants';
-import { Logger } from './logger';
+import {cls, RootContext} from './cls';
+import {OpenCensusPropagation, TracePolicy} from './config';
+import {Constants, SpanType} from './constants';
+import {Logger} from './logger';
 import {
   Func,
   Propagation,
@@ -38,9 +38,9 @@ import {
   DISABLED_ROOT_SPAN,
   UntracedRootSpanData,
 } from './span-data';
-import { TraceLabels } from './trace-labels';
-import { traceWriter } from './trace-writer';
-import { neverTrace } from './tracing-policy';
+import {TraceLabels} from './trace-labels';
+import {traceWriter} from './trace-writer';
+import {neverTrace} from './tracing-policy';
 import * as util from './util';
 
 /**
@@ -111,7 +111,7 @@ export class StackdriverTracer implements Tracer {
           -16
         ),
       });
-      this.headerPropagation!.inject({ setHeader }, value);
+      this.headerPropagation!.inject({setHeader}, value);
     },
   };
 
@@ -195,7 +195,7 @@ export class StackdriverTracer implements Tracer {
       return fn(DISABLED_ROOT_SPAN);
     }
 
-    options = options || { name: '' };
+    options = options || {name: ''};
 
     // Don't create a root span if we are already in a root span
     const rootSpan = cls.get().getContext();
@@ -305,7 +305,7 @@ export class StackdriverTracer implements Tracer {
       return DISABLED_CHILD_SPAN;
     }
 
-    options = options || { name: '' };
+    options = options || {name: ''};
     const rootSpan = cls.get().getContext();
     if (rootSpan.type === SpanType.ROOT) {
       if (!!rootSpan.span.endTime) {

--- a/src/trace-plugin-loader.ts
+++ b/src/trace-plugin-loader.ts
@@ -19,15 +19,15 @@ import * as path from 'path';
 import * as hook from 'require-in-the-middle';
 import * as semver from 'semver';
 
-import { TracePolicy } from './config';
-import { Logger } from './logger';
-import { Intercept, Monkeypatch, Plugin } from './plugin-types';
+import {TracePolicy} from './config';
+import {Logger} from './logger';
+import {Intercept, Monkeypatch, Plugin} from './plugin-types';
 import {
   StackdriverTracer,
   StackdriverTracerComponents,
   StackdriverTracerConfig,
 } from './trace-api';
-import { Singleton } from './util';
+import {Singleton} from './util';
 
 /**
  * Plugins are user-provided objects containing functions that should be run
@@ -43,7 +43,7 @@ import { Singleton } from './util';
 export interface PluginLoaderConfig {
   // An object which contains paths to files that should be loaded as plugins
   // upon loading a module with a given name.
-  plugins: { [pluginName: string]: string };
+  plugins: {[pluginName: string]: string};
   tracerConfig: StackdriverTracerConfig;
 }
 
@@ -319,7 +319,7 @@ export class PluginLoader {
     // Initialize ALL of the PluginWrapper objects here.
     // See CorePluginWrapper docs for why core modules are processed
     // differently.
-    const coreWrapperConfig: CorePluginWrapperOptions = { children: [] };
+    const coreWrapperConfig: CorePluginWrapperOptions = {children: []};
     Object.keys(config.plugins).forEach(key => {
       const value = config.plugins[key];
       // Core module plugins share a common key.
@@ -330,12 +330,12 @@ export class PluginLoader {
         // Convert the given string value to a PluginConfigEntry
         // (unless it's falsey).
         if (coreModule) {
-          coreWrapperConfig.children.push({ name: key, path: value });
+          coreWrapperConfig.children.push({name: key, path: value});
         } else {
           this.pluginMap.set(
             key,
             new ModulePluginWrapper(
-              { name: key, path: value },
+              {name: key, path: value},
               config.tracerConfig,
               components
             )
@@ -365,7 +365,7 @@ export class PluginLoader {
       const builtins = this.pluginMap.has(PluginLoader.CORE_MODULE)
         ? builtinModules
         : [];
-      hook(builtins.concat(nonCoreModules), { internals: true }, onRequire);
+      hook(builtins.concat(nonCoreModules), {internals: true}, onRequire);
     };
   }
 
@@ -483,7 +483,7 @@ export class PluginLoader {
    * @param moduleStr The module string; in the form of either `${module}` or
    *   `${module}/${relPath}`
    */
-  static parseModuleString(moduleStr: string): { name: string; file: string } {
+  static parseModuleString(moduleStr: string): {name: string; file: string} {
     // Canonicalize the name by using only '/'.
     const parts = moduleStr.replace(/\\/g, '/').split('/');
     // The separation index between name/file depends on whether the module

--- a/src/trace-writer.ts
+++ b/src/trace-writer.ts
@@ -16,14 +16,14 @@
 
 import * as common from '@google-cloud/common';
 import * as gcpMetadata from 'gcp-metadata';
-import { OutgoingHttpHeaders } from 'http';
+import {OutgoingHttpHeaders} from 'http';
 import * as os from 'os';
 
-import { Constants } from './constants';
-import { Logger } from './logger';
-import { SpanKind, Trace } from './trace';
-import { TraceLabels } from './trace-labels';
-import { Singleton } from './util';
+import {Constants} from './constants';
+import {Logger} from './logger';
+import {SpanKind, Trace} from './trace';
+import {TraceLabels} from './trace-labels';
+import {Singleton} from './util';
 
 const pjson = require('../../package.json');
 
@@ -47,7 +47,7 @@ export interface TraceWriterConfig {
   flushDelaySeconds: number;
   stackTraceLimit: number;
   maximumLabelValueSize: number;
-  serviceContext: { service?: string; version?: string; minorVersion?: string };
+  serviceContext: {service?: string; version?: string; minorVersion?: string};
 }
 
 export interface LabelObject {
@@ -221,7 +221,7 @@ export class TraceWriter extends common.Service {
 
   private async getHostname(): Promise<string> {
     try {
-      return await gcpMetadata.instance({ property: 'hostname', headers });
+      return await gcpMetadata.instance({property: 'hostname', headers});
     } catch (err) {
       if (err.code !== 'ENOTFOUND') {
         // We are running on GCP.
@@ -237,7 +237,7 @@ export class TraceWriter extends common.Service {
 
   private async getInstanceId(): Promise<number | null> {
     try {
-      return await gcpMetadata.instance({ property: 'id', headers });
+      return await gcpMetadata.instance({property: 'id', headers});
     } catch (err) {
       if (err.code !== 'ENOTFOUND') {
         // We are running on GCP.
@@ -329,7 +329,7 @@ export class TraceWriter extends common.Service {
         'TraceWriter#flushBuffer: Flushing traces',
         flushedTraces
       );
-      this.publish(JSON.stringify({ traces: flushedTraces }));
+      this.publish(JSON.stringify({traces: flushedTraces}));
     };
 
     // TODO(kjin): We should always be following the 'else' path.
@@ -358,7 +358,7 @@ export class TraceWriter extends common.Service {
   protected publish(json: string) {
     const hostname = 'cloudtrace.googleapis.com';
     const uri = `https://${hostname}/v1/projects/${this.projectId}/traces`;
-    const options = { method: 'PATCH', uri, body: json, headers };
+    const options = {method: 'PATCH', uri, body: json, headers};
     this.logger.info('TraceWriter#publish: Publishing to ' + uri);
     this.request(options, (err, body?, response?) => {
       const statusCode = response && response.statusCode;

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -24,7 +24,7 @@ export enum SpanKind {
 }
 
 export interface TraceSpan {
-  labels: { [key: string]: string };
+  labels: {[key: string]: string};
   startTime: string;
   endTime: string;
   kind: SpanKind;

--- a/src/tracing-policy.ts
+++ b/src/tracing-policy.ts
@@ -1,6 +1,6 @@
-import { RequestDetails, TracePolicy } from './config';
-import { Constants } from './constants';
-import { TraceContext } from './util';
+import {RequestDetails, TracePolicy} from './config';
+import {Constants} from './constants';
+import {TraceContext} from './util';
 
 /**
  * Copyright 2015 Google Inc. All Rights Reserved.
@@ -155,24 +155,24 @@ export class BuiltinTracePolicy implements TracePolicy {
    */
   constructor(config: TracePolicyConfig) {
     if (config.samplingRate === 0) {
-      this.sampler = { shouldTrace: () => true };
+      this.sampler = {shouldTrace: () => true};
     } else if (config.samplingRate < 0) {
-      this.sampler = { shouldTrace: () => false };
+      this.sampler = {shouldTrace: () => false};
     } else {
       this.sampler = new Sampler(config.samplingRate);
     }
     if (config.ignoreUrls.length === 0) {
-      this.urlFilter = { shouldTrace: () => true };
+      this.urlFilter = {shouldTrace: () => true};
     } else {
       this.urlFilter = new URLFilter(config.ignoreUrls);
     }
     if (config.ignoreMethods.length === 0) {
-      this.methodsFilter = { shouldTrace: () => true };
+      this.methodsFilter = {shouldTrace: () => true};
     } else {
       this.methodsFilter = new MethodsFilter(config.ignoreMethods);
     }
     if (config.contextHeaderBehavior === TraceContextHeaderBehavior.IGNORE) {
-      this.contextHeaderFilter = { shouldTrace: () => true };
+      this.contextHeaderFilter = {shouldTrace: () => true};
     } else {
       this.contextHeaderFilter = new ContextHeaderFilter(
         config.contextHeaderBehavior

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import { StackdriverFormat } from '@opencensus/propagation-stackdriver';
+import {StackdriverFormat} from '@opencensus/propagation-stackdriver';
 import * as path from 'path';
 
-import { cls, TraceCLSConfig } from './cls';
-import { OpenCensusPropagation, TracePolicy } from './config';
-import { LEVELS, Logger } from './logger';
-import { StackdriverTracer } from './trace-api';
-import { pluginLoader, PluginLoaderConfig } from './trace-plugin-loader';
-import { traceWriter, TraceWriterConfig } from './trace-writer';
-import { BuiltinTracePolicy, TracePolicyConfig } from './tracing-policy';
-import { Component, Forceable, packageNameFromPath, Singleton } from './util';
+import {cls, TraceCLSConfig} from './cls';
+import {OpenCensusPropagation, TracePolicy} from './config';
+import {LEVELS, Logger} from './logger';
+import {StackdriverTracer} from './trace-api';
+import {pluginLoader, PluginLoaderConfig} from './trace-plugin-loader';
+import {traceWriter, TraceWriterConfig} from './trace-writer';
+import {BuiltinTracePolicy, TracePolicyConfig} from './tracing-policy';
+import {Component, Forceable, packageNameFromPath, Singleton} from './util';
 
 export type TopLevelConfig =
   | Forceable<{
@@ -143,7 +143,7 @@ export class Tracing implements Component {
     const propagation =
       this.config.overrides.propagation || new StackdriverFormat();
 
-    const tracerComponents = { logger: this.logger, tracePolicy, propagation };
+    const tracerComponents = {logger: this.logger, tracePolicy, propagation};
 
     this.traceAgent.enable(
       this.config.pluginLoaderConfig.tracerConfig,

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,9 +19,9 @@ import * as sourceMapSupport from 'source-map-support';
 const {
   hexToDec,
   decToHex,
-}: { [key: string]: (input: string) => string } = require('hex2dec');
+}: {[key: string]: (input: string) => string} = require('hex2dec');
 
-export { hexToDec, decToHex };
+export {hexToDec, decToHex};
 
 // This symbol must be exported (for now).
 // See: https://github.com/Microsoft/TypeScript/issues/20080
@@ -53,7 +53,7 @@ export interface Constructor<T, ConfigType, LoggerType> {
 
 export const FORCE_NEW = Symbol('force-new');
 
-export type Forceable<T> = T & { [FORCE_NEW]?: boolean };
+export type Forceable<T> = T & {[FORCE_NEW]?: boolean};
 
 export interface Component {
   enable(): void;
@@ -251,7 +251,7 @@ export function createStackTrace(
   ): NodeJS.CallSite[] => {
     return structured.map(sourceMapSupport.wrapCallSite);
   };
-  const e: { stack?: NodeJS.CallSite[] } = {};
+  const e: {stack?: NodeJS.CallSite[]} = {};
   Error.captureStackTrace(e, constructorOpt);
 
   const stackFrames: StackFrame[] = [];
@@ -322,7 +322,7 @@ export function serializeTraceContext(traceContext: TraceContext): Buffer {
  * @param buffer The trace context to deserialize.
  */
 export function deserializeTraceContext(buffer: Buffer): TraceContext | null {
-  const result: TraceContext = { traceId: '', spanId: '' };
+  const result: TraceContext = {traceId: '', spanId: ''};
   // Length must be 29.
   if (buffer.length !== 29) {
     return null;

--- a/test/logger.ts
+++ b/test/logger.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { LEVELS, Logger, LoggerConfig } from '../src/logger';
+import {LEVELS, Logger, LoggerConfig} from '../src/logger';
 
 const PASS_THROUGH_LOG_LEVEL = Number(process.env.GCLOUD_TEST_LOG_LEVEL || 0);
 // Capture the value of common.Logger so that we don't enter an infinite loop
@@ -26,7 +26,7 @@ const OriginalLogger = Logger;
 type LoggerFunction<R> = (message: any, ...args: any[]) => R;
 
 export class TestLogger extends Logger {
-  private logs: { [k in keyof Logger]: string[] } = {
+  private logs: {[k in keyof Logger]: string[]} = {
     error: [],
     warn: [],
     info: [],
@@ -37,7 +37,7 @@ export class TestLogger extends Logger {
   });
 
   constructor(options?: Partial<LoggerConfig>) {
-    super(Object.assign({ tag: '@google-cloud/trace-agent' }, options));
+    super(Object.assign({tag: '@google-cloud/trace-agent'}, options));
   }
 
   private makeLoggerFn(logLevel: keyof Logger): LoggerFunction<this> {

--- a/test/nocks.ts
+++ b/test/nocks.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { HOST_ADDRESS } from 'gcp-metadata';
+import {HOST_ADDRESS} from 'gcp-metadata';
 import * as nock from 'nock';
 
 const accept = () => true;
@@ -44,7 +44,7 @@ export function projectId(
   return nock(HOST_ADDRESS)
     .get('/computeMetadata/v1/project/project-id')
     .once()
-    .reply(status, reply, { 'Metadata-Flavor': 'Google' });
+    .reply(status, reply, {'Metadata-Flavor': 'Google'});
 }
 
 export function instanceId(
@@ -58,7 +58,7 @@ export function instanceId(
   return nock(HOST_ADDRESS)
     .get('/computeMetadata/v1/instance/id')
     .once()
-    .reply(status, reply, { 'Metadata-Flavor': 'Google' });
+    .reply(status, reply, {'Metadata-Flavor': 'Google'});
 }
 
 export function hostname(
@@ -72,5 +72,5 @@ export function hostname(
   return nock(HOST_ADDRESS)
     .get('/computeMetadata/v1/instance/hostname')
     .once()
-    .reply(status, reply, { 'Metadata-Flavor': 'Google' });
+    .reply(status, reply, {'Metadata-Flavor': 'Google'});
 }

--- a/test/plugins/test-cls-bluebird.ts
+++ b/test/plugins/test-cls-bluebird.ts
@@ -16,8 +16,8 @@
 
 import * as assert from 'assert';
 
-import { bluebird_3 as BluebirdPromise } from '../../src/plugins/types';
-import { Trace } from '../../src/trace';
+import {bluebird_3 as BluebirdPromise} from '../../src/plugins/types';
+import {Trace} from '../../src/trace';
 import * as traceTestModule from '../trace';
 
 /**
@@ -51,11 +51,11 @@ const getTracesForPromiseImplementation = <T>(
   return new Promise((resolve, reject) => {
     const tracer = traceTestModule.get();
     let p: BluebirdPromise<T>;
-    const firstSpan = tracer.runInRootSpan({ name: 'first' }, span => {
+    const firstSpan = tracer.runInRootSpan({name: 'first'}, span => {
       p = makePromise();
       return span;
     });
-    tracer.runInRootSpan({ name: 'second' }, secondSpan => {
+    tracer.runInRootSpan({name: 'second'}, secondSpan => {
       // Note to maintainers: Do NOT convert this to async/await,
       // as it changes context propagation behavior.
       thenFn(p, () => {

--- a/test/plugins/test-trace-google-gax.ts
+++ b/test/plugins/test-trace-google-gax.ts
@@ -38,7 +38,7 @@
 import * as assert from 'assert';
 
 import * as testTraceModule from '../trace';
-import { describeInterop } from '../utils';
+import {describeInterop} from '../utils';
 
 interface ApiCallSettings {
   merge: () => {
@@ -54,7 +54,7 @@ type InnerApiCall<I, O> = (
 ) => void;
 type OuterApiCall<I, O> = (
   request: I,
-  options: { timeout: number },
+  options: {timeout: number},
   callback: Callback<O>
 ) => void;
 interface GaxModule {
@@ -84,20 +84,20 @@ describeInterop<GaxModule>('google-gax', fixture => {
       // Simulate an RPC.
       testTraceModule
         .get()
-        .createChildSpan({ name: 'in-request' })
+        .createChildSpan({name: 'in-request'})
         .endSpan();
       setImmediate(() => cb(null, {}));
     }) as InnerApiCall<{}, {}>);
     const apiCall = googleGax.createApiCall(authPromise, {
-      merge: () => ({ otherArgs: {} }),
+      merge: () => ({otherArgs: {}}),
     });
 
-    testTraceModule.get().runInRootSpan({ name: 'root' }, root => {
-      apiCall({}, { timeout: 20 }, err => {
+    testTraceModule.get().runInRootSpan({name: 'root'}, root => {
+      apiCall({}, {timeout: 20}, err => {
         assert.ifError(err);
         testTraceModule
           .get()
-          .createChildSpan({ name: 'in-callback' })
+          .createChildSpan({name: 'in-callback'})
           .endSpan();
         root.endSpan();
 

--- a/test/plugins/test-trace-http.ts
+++ b/test/plugins/test-trace-http.ts
@@ -15,22 +15,22 @@
  */
 
 import * as assert from 'assert';
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 import * as fs from 'fs';
 import * as httpModule from 'http';
 import * as httpsModule from 'https';
-import { AddressInfo } from 'net';
+import {AddressInfo} from 'net';
 import * as path from 'path';
 import * as semver from 'semver';
 import * as stream from 'stream';
-import { URL } from 'url';
+import {URL} from 'url';
 
-import { Constants } from '../../src/constants';
-import { SpanKind, TraceSpan } from '../../src/trace';
-import { parseContextFromHeader, TraceContext } from '../../src/util';
+import {Constants} from '../../src/constants';
+import {SpanKind, TraceSpan} from '../../src/trace';
+import {parseContextFromHeader, TraceContext} from '../../src/util';
 import * as testTraceModule from '../trace';
-import { assertSpanDuration, DEFAULT_SPAN_DURATION } from '../utils';
-import { Express4 } from '../web-frameworks/express';
+import {assertSpanDuration, DEFAULT_SPAN_DURATION} from '../utils';
+import {Express4} from '../web-frameworks/express';
 
 // This type describes (http|https).(get|request).
 type HttpRequest = (
@@ -102,7 +102,7 @@ class Express4Secure extends Express4 {
     // The types of (http|https).Server are not compatible, but we don't
     // access any properties that aren't present on both in the test.
     this.server = (this.https.createServer(
-      { key: Express4Secure.key, cert: Express4Secure.cert },
+      {key: Express4Secure.key, cert: Express4Secure.cert},
       this.app
     ) as {}) as httpModule.Server;
     this.server.listen(port);
@@ -126,7 +126,7 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
   // tslint:disable-next-line:variable-name
   const ServerFramework = servers[nodule];
   describe(`${nodule} client tracing`, () => {
-    let http: { get: HttpRequest; request: HttpRequest };
+    let http: {get: HttpRequest; request: HttpRequest};
     before(() => {
       testTraceModule.setCLSForTest();
       testTraceModule.setPluginLoaderForTest();
@@ -152,7 +152,7 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
           fn: async () => {
             const waitForResponse = new WaitForResponse();
             http.get(
-              { port, rejectUnauthorized: false },
+              {port, rejectUnauthorized: false},
               waitForResponse.handleResponse
             );
             await waitForResponse.done;
@@ -162,7 +162,7 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
           description: 'calling http.get and using return value',
           fn: async () => {
             const waitForResponse = new WaitForResponse();
-            const req = http.get({ port, rejectUnauthorized: false });
+            const req = http.get({port, rejectUnauthorized: false});
             req.on('response', waitForResponse.handleResponse);
             await waitForResponse.done;
           },
@@ -171,7 +171,7 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
           description: 'calling http.get and piping from res',
           fn: async () => {
             const waitForResponse = new WaitForResponse();
-            http.get({ port, rejectUnauthorized: false }, res => {
+            http.get({port, rejectUnauthorized: false}, res => {
               let result = '';
               const writable = new stream.Writable();
               writable._write = (chunk, encoding, next) => {
@@ -193,7 +193,7 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
           fn: async () => {
             const waitForResponse = new WaitForResponse();
             const req = http.request(
-              { port, rejectUnauthorized: false },
+              {port, rejectUnauthorized: false},
               waitForResponse.handleResponse
             );
             req.end();
@@ -207,7 +207,7 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
             // Express4 instance.
             server.server!.timeout = DEFAULT_SPAN_DURATION / 2;
             const waitForResponse = new WaitForResponse();
-            const req = http.get({ port, rejectUnauthorized: false });
+            const req = http.get({port, rejectUnauthorized: false});
             req.on('error', () => {
               waitForResponse.handleDone();
             });
@@ -222,7 +222,7 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
               {
                 port,
                 rejectUnauthorized: false,
-                headers: { [key]: '100-continue' },
+                headers: {[key]: '100-continue'},
               },
               waitForResponse.handleResponse
             );
@@ -238,7 +238,7 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
           hasResponse: true,
           fn: async () => {
             await wait(DEFAULT_SPAN_DURATION);
-            return { statusCode: 200, message: 'hi' };
+            return {statusCode: 200, message: 'hi'};
           },
         });
         port = server.listen(0);
@@ -253,7 +253,7 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
           let recordedTime = 0;
           await testTraceModule
             .get()
-            .runInRootSpan({ name: 'outer' }, async rootSpan => {
+            .runInRootSpan({name: 'outer'}, async rootSpan => {
               assert.ok(testTraceModule.get().isRealSpan(rootSpan));
               recordedTime = Date.now();
               await testCase.fn();
@@ -277,14 +277,14 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
         path: '/',
         hasResponse: true,
         fn: async () => {
-          return { statusCode: 200, message: 'hi' };
+          return {statusCode: 200, message: 'hi'};
         },
       });
       const port = server.listen(0);
       try {
         await testTraceModule
           .get()
-          .runInRootSpan({ name: 'outer' }, async rootSpan => {
+          .runInRootSpan({name: 'outer'}, async rootSpan => {
             assert.ok(testTraceModule.get().isRealSpan(rootSpan));
             const waitForResponse = new WaitForResponse();
             http.get(
@@ -317,18 +317,18 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
           serverCapturedTraceContext = parseContextFromHeader(
             traceContext as string
           );
-          return { statusCode: 200, message: 'hi' };
+          return {statusCode: 200, message: 'hi'};
         },
       });
       const port = server.listen(0);
       try {
         await testTraceModule
           .get()
-          .runInRootSpan({ name: 'root' }, async rootSpan => {
+          .runInRootSpan({name: 'root'}, async rootSpan => {
             assert.ok(testTraceModule.get().isRealSpan(rootSpan));
             const waitForResponse = new WaitForResponse();
             http.get(
-              { port, rejectUnauthorized: false },
+              {port, rejectUnauthorized: false},
               waitForResponse.handleResponse
             );
             await waitForResponse.done;
@@ -359,18 +359,18 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
         path: '/',
         hasResponse: true,
         fn: async () => {
-          return { statusCode: 200, message: 'hi' };
+          return {statusCode: 200, message: 'hi'};
         },
       });
       const port = server.listen(0);
       try {
         await testTraceModule
           .get()
-          .runInRootSpan({ name: 'outer' }, async rootSpan => {
+          .runInRootSpan({name: 'outer'}, async rootSpan => {
             assert.ok(testTraceModule.get().isRealSpan(rootSpan));
             const waitForResponse = new WaitForResponse();
             http.get(
-              { port, rejectUnauthorized: false },
+              {port, rejectUnauthorized: false},
               waitForResponse.handleResponse
             );
             await waitForResponse.done;
@@ -379,7 +379,7 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
             // We make sure that trace context is still accessible here.
             const afterHttpSpan = testTraceModule
               .get()
-              .createChildSpan({ name: 'after-http' });
+              .createChildSpan({name: 'after-http'});
             assert.ok(testTraceModule.get().isRealSpan(afterHttpSpan));
             afterHttpSpan.endSpan();
             rootSpan.endSpan();
@@ -395,14 +395,14 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
         path: '/',
         hasResponse: true,
         fn: async () => {
-          return { statusCode: 200, message: 'hi' };
+          return {statusCode: 200, message: 'hi'};
         },
       });
       const port = server.listen(0);
       try {
         await testTraceModule
           .get()
-          .runInRootSpan({ name: 'outer' }, async rootSpan => {
+          .runInRootSpan({name: 'outer'}, async rootSpan => {
             assert.ok(testTraceModule.get().isRealSpan(rootSpan));
             const waitForResponse = new WaitForResponse();
             const headers: httpModule.OutgoingHttpHeaders = {};
@@ -410,7 +410,7 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
               testTraceModule.get().constants.TRACE_AGENT_REQUEST_HEADER
             ] = 'yay';
             http.get(
-              { port, rejectUnauthorized: false, headers },
+              {port, rejectUnauthorized: false, headers},
               waitForResponse.handleResponse
             );
             await waitForResponse.done;
@@ -427,7 +427,7 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
 
     it('should not break with no target', () => {
       return new Promise(resolve =>
-        testTraceModule.get().runInRootSpan({ name: 'outer' }, rootSpan => {
+        testTraceModule.get().runInRootSpan({name: 'outer'}, rootSpan => {
           assert.ok(testTraceModule.get().isRealSpan(rootSpan));
           (http.get as (arg?: {}) => EventEmitter)().on('error', err => {
             resolve();
@@ -445,20 +445,20 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
         hasResponse: true,
         fn: async () => {
           await wait(DEFAULT_SPAN_DURATION);
-          return { statusCode: statusCode++, message: 'hi' };
+          return {statusCode: statusCode++, message: 'hi'};
         },
       });
       const port = server.listen(0);
       try {
         await testTraceModule
           .get()
-          .runInRootSpan({ name: 'outer' }, async rootSpan => {
+          .runInRootSpan({name: 'outer'}, async rootSpan => {
             await Promise.all(
               [0, 1, 2, 3, 4].map(async i => {
                 assert.ok(testTraceModule.get().isRealSpan(rootSpan));
                 const waitForResponse = new WaitForResponse();
                 http.get(
-                  { port, rejectUnauthorized: false },
+                  {port, rejectUnauthorized: false},
                   waitForResponse.handleResponse
                 );
                 await waitForResponse.done;
@@ -500,23 +500,23 @@ for (const nodule of Object.keys(servers) as Array<keyof typeof servers>) {
           hasResponse: true,
           fn: async () => {
             await wait(DEFAULT_SPAN_DURATION);
-            return { statusCode: 200, message: 'hi' };
+            return {statusCode: 200, message: 'hi'};
           },
         });
         port = server.listen(0);
         await testTraceModule
           .get()
-          .runInRootSpan({ name: 'outer' }, async rootSpan => {
+          .runInRootSpan({name: 'outer'}, async rootSpan => {
             assert.ok(testTraceModule.get().isRealSpan(rootSpan));
             let waitForResponse = new WaitForResponse();
             http.get(
-              { port, rejectUnauthorized: false, path: '/?foo=bar' },
+              {port, rejectUnauthorized: false, path: '/?foo=bar'},
               waitForResponse.handleResponse
             );
             await waitForResponse.done;
             server.server!.timeout = DEFAULT_SPAN_DURATION / 2;
             waitForResponse = new WaitForResponse();
-            http.get({ port, rejectUnauthorized: false }).on('error', () => {
+            http.get({port, rejectUnauthorized: false}).on('error', () => {
               waitForResponse.handleDone();
             });
             await waitForResponse.done;

--- a/test/plugins/test-trace-http2.ts
+++ b/test/plugins/test-trace-http2.ts
@@ -21,8 +21,8 @@ import * as http2Types from 'http2';
 import * as semver from 'semver';
 import * as stream from 'stream';
 
-import { Constants, SpanType } from '../../src/constants';
-import { TraceLabels } from '../../src/trace-labels';
+import {Constants, SpanType} from '../../src/constants';
+import {TraceLabels} from '../../src/trace-labels';
 import * as traceTestModule from '../trace';
 import {
   assertSpanDuration,
@@ -65,7 +65,7 @@ maybeSkipHttp2('Trace Agent integration with http2', () => {
       server = http2.createServer();
       server.on('stream', s => {
         setTimeout(() => {
-          s.respond({ ':status': 200 });
+          s.respond({':status': 200});
           s.end(serverRes);
         }, DEFAULT_SPAN_DURATION);
       });
@@ -85,11 +85,11 @@ maybeSkipHttp2('Trace Agent integration with http2', () => {
 
     it('should accurately measure request time', done => {
       server.listen(serverPort, () => {
-        traceTestModule.get().runInRootSpan({ name: 'outer' }, rootSpan => {
+        traceTestModule.get().runInRootSpan({name: 'outer'}, rootSpan => {
           assert.ok(rootSpan.type === SpanType.ROOT);
           const start = Date.now();
           const session = http2.connect(`http://localhost:${serverPort}`);
-          const s = session.request({ ':path': '/' });
+          const s = session.request({':path': '/'});
           s.setEncoding('utf8');
           let result = '';
           s.on('data', (data: string) => {
@@ -111,10 +111,10 @@ maybeSkipHttp2('Trace Agent integration with http2', () => {
 
     it('should propagate context', done => {
       server.listen(serverPort, () => {
-        traceTestModule.get().runInRootSpan({ name: 'outer' }, rootSpan => {
+        traceTestModule.get().runInRootSpan({name: 'outer'}, rootSpan => {
           assert.ok(rootSpan.type === SpanType.ROOT);
           const session = http2.connect(`http://localhost:${serverPort}`);
-          const s = session.request({ ':path': '/' });
+          const s = session.request({':path': '/'});
           s.on('data', () => {
             assert.ok(hasContext());
           }).on('end', () => {
@@ -130,10 +130,10 @@ maybeSkipHttp2('Trace Agent integration with http2', () => {
 
     it('should not trace api requests', done => {
       server.listen(serverPort, () => {
-        traceTestModule.get().runInRootSpan({ name: 'outer' }, rootSpan => {
+        traceTestModule.get().runInRootSpan({name: 'outer'}, rootSpan => {
           assert.ok(rootSpan.type === SpanType.ROOT);
           const session = http2.connect(`http://localhost:${serverPort}`);
-          const headers: http2Types.OutgoingHttpHeaders = { ':path': '/' };
+          const headers: http2Types.OutgoingHttpHeaders = {':path': '/'};
           headers[Constants.TRACE_AGENT_REQUEST_HEADER] = 'yay';
           const s = session.request(headers);
           s.end();
@@ -153,7 +153,7 @@ maybeSkipHttp2('Trace Agent integration with http2', () => {
 
     it('should not break with no headers', done => {
       server.listen(serverPort, () => {
-        traceTestModule.get().runInRootSpan({ name: 'outer' }, rootSpan => {
+        traceTestModule.get().runInRootSpan({name: 'outer'}, rootSpan => {
           assert.ok(rootSpan.type === SpanType.ROOT);
           const session = http2.connect(`http://localhost:${serverPort}`);
           // `headers` are not passed
@@ -183,11 +183,11 @@ maybeSkipHttp2('Trace Agent integration with http2', () => {
 
     it('should leave request streams in paused mode', done => {
       server.listen(serverPort, () => {
-        traceTestModule.get().runInRootSpan({ name: 'outer' }, rootSpan => {
+        traceTestModule.get().runInRootSpan({name: 'outer'}, rootSpan => {
           assert.ok(rootSpan.type === SpanType.ROOT);
           const start = Date.now();
           const session = http2.connect(`http://localhost:${serverPort}`);
-          const s = session.request({ ':path': '/' });
+          const s = session.request({':path': '/'});
           let result = '';
           const writable = new stream.Writable();
           writable._write = (chunk, encoding, next) => {
@@ -214,10 +214,10 @@ maybeSkipHttp2('Trace Agent integration with http2', () => {
 
     it('should not include query parameters in span name', done => {
       server.listen(serverPort, () => {
-        traceTestModule.get().runInRootSpan({ name: 'outer' }, rootSpan => {
+        traceTestModule.get().runInRootSpan({name: 'outer'}, rootSpan => {
           assert.ok(rootSpan.type === SpanType.ROOT);
           const session = http2.connect(`http://localhost:${serverPort}`);
-          const s = session.request({ ':path': '/?foo=bar' });
+          const s = session.request({':path': '/?foo=bar'});
           s.on('data', () => {}); // enter flowing mode
           s.end();
           setTimeout(() => {
@@ -234,10 +234,10 @@ maybeSkipHttp2('Trace Agent integration with http2', () => {
 
     it('custom port number must be included in the url label', done => {
       server.listen(serverPort, () => {
-        traceTestModule.get().runInRootSpan({ name: 'outer' }, rootSpan => {
+        traceTestModule.get().runInRootSpan({name: 'outer'}, rootSpan => {
           assert.ok(rootSpan.type === SpanType.ROOT);
           const session = http2.connect(`http://localhost:${serverPort}`);
-          const s = session.request({ ':path': '/' });
+          const s = session.request({':path': '/'});
           s.on('data', () => {}); // enter flowing mode
           s.end();
           setTimeout(() => {
@@ -260,8 +260,7 @@ maybeSkipHttp2('Trace Agent integration with http2', () => {
       server.on(
         'stream',
         (
-          s: http2Types.ServerHttp2Stream &
-            ({ rstWithInternalError: () => void })
+          s: http2Types.ServerHttp2Stream & ({rstWithInternalError: () => void})
         ) => {
           // In Node 9.9+, the error handler is not added by default.
           s.on('error', () => {});
@@ -277,11 +276,11 @@ maybeSkipHttp2('Trace Agent integration with http2', () => {
         }
       );
       server.listen(serverPort, () => {
-        traceTestModule.get().runInRootSpan({ name: 'outer' }, rootSpan => {
+        traceTestModule.get().runInRootSpan({name: 'outer'}, rootSpan => {
           assert.ok(rootSpan.type === SpanType.ROOT);
           const start = Date.now();
           const session = http2.connect(`http://localhost:${serverPort}`);
-          const s = session.request({ ':path': '/' });
+          const s = session.request({':path': '/'});
           s.on('error', () => {
             rootSpan.endSpan();
             const span = traceTestModule.getOneSpan(
@@ -324,7 +323,7 @@ maybeSkipHttp2('Trace Agent integration with http2', () => {
 
     it('should accurately measure request time, event emitter', done => {
       server.listen(serverPort, () => {
-        traceTestModule.get().runInRootSpan({ name: 'outer' }, rootSpan => {
+        traceTestModule.get().runInRootSpan({name: 'outer'}, rootSpan => {
           assert.ok(rootSpan.type === SpanType.ROOT);
           const start = Date.now();
           const session = http2.connect(`http://localhost:${serverPort}`);
@@ -357,17 +356,17 @@ maybeSkipHttp2('Trace Agent integration with http2', () => {
       const slowServer: http2Types.Http2Server = http2.createServer();
       slowServer.on('stream', s => {
         setTimeout(() => {
-          s.respond({ ':status': count++ });
+          s.respond({':status': count++});
           s.end();
         }, 5000);
       });
       slowServer.listen(serverPort, () => {
-        traceTestModule.get().runInRootSpan({ name: 'outer' }, rootSpan => {
+        traceTestModule.get().runInRootSpan({name: 'outer'}, rootSpan => {
           assert.ok(rootSpan.type === SpanType.ROOT);
           let completed = 0;
           for (let i = 0; i < 5; i++) {
             const session = http2.connect(`http://localhost:${serverPort}`);
-            const s = session.request({ ':path': '/' });
+            const s = session.request({':path': '/'});
             s.on('data', () => {}).on('end', () => {
               if (++completed === 5) {
                 rootSpan.endSpan();
@@ -408,18 +407,18 @@ maybeSkipHttp2('Trace Agent integration with http2', () => {
       );
       secureServer.on('stream', s => {
         setTimeout(() => {
-          s.respond({ ':status': 200 });
+          s.respond({':status': 200});
           s.end(serverRes);
         }, DEFAULT_SPAN_DURATION);
       });
       secureServer.listen(serverPort, () => {
-        traceTestModule.get().runInRootSpan({ name: 'outer' }, rootSpan => {
+        traceTestModule.get().runInRootSpan({name: 'outer'}, rootSpan => {
           assert.ok(rootSpan.type === SpanType.ROOT);
           const start = Date.now();
           const session = http2.connect(`https://localhost:${serverPort}`, {
             rejectUnauthorized: false,
           });
-          const s = session.request({ ':path': '/' });
+          const s = session.request({':path': '/'});
           s.setEncoding('utf8');
           let result = '';
           s.on('data', (data: string) => {

--- a/test/plugins/test-trace-knex.ts
+++ b/test/plugins/test-trace-knex.ts
@@ -17,10 +17,10 @@
 import * as assert from 'assert';
 import * as knexTypes from 'knex';
 
-import { Tracer } from '../../src/plugin-types';
-import { TraceLabels } from '../../src/trace-labels';
+import {Tracer} from '../../src/plugin-types';
+import {TraceLabels} from '../../src/trace-labels';
 import * as traceTestModule from '../trace';
-import { describeInterop, hasContext, wait } from '../utils';
+import {describeInterop, hasContext, wait} from '../utils';
 
 const TABLE_NAME = 't';
 
@@ -30,7 +30,7 @@ const obj = {
 };
 
 describeInterop<typeof knexTypes>('knex', fixture => {
-  const { version, parsedVersion } = fixture;
+  const {version, parsedVersion} = fixture;
 
   let knex: knexTypes;
   let tracer: Tracer;
@@ -38,7 +38,7 @@ describeInterop<typeof knexTypes>('knex', fixture => {
   before(() => {
     traceTestModule.setCLSForTest();
     traceTestModule.setPluginLoaderForTest();
-    tracer = traceTestModule.start({ enhancedDatabaseReporting: true });
+    tracer = traceTestModule.start({enhancedDatabaseReporting: true});
     knex = fixture.require()({
       client: 'mysql',
       connection: require('../mysql-config'),
@@ -79,7 +79,7 @@ describeInterop<typeof knexTypes>('knex', fixture => {
   });
 
   it('should perform basic operations using ' + version, () => {
-    return tracer.runInRootSpan({ name: 'outer' }, rootSpan => {
+    return tracer.runInRootSpan({name: 'outer'}, rootSpan => {
       return knex(TABLE_NAME)
         .select()
         .then(res => {
@@ -104,7 +104,7 @@ describeInterop<typeof knexTypes>('knex', fixture => {
   });
 
   it('should propagate context using ' + version, () => {
-    return tracer.runInRootSpan({ name: 'outer' }, rootSpan => {
+    return tracer.runInRootSpan({name: 'outer'}, rootSpan => {
       return knex
         .select()
         .from(TABLE_NAME)
@@ -116,7 +116,7 @@ describeInterop<typeof knexTypes>('knex', fixture => {
   });
 
   it('should remove trace frames from stack using ' + version, () => {
-    return tracer.runInRootSpan({ name: 'outer' }, rootSpan => {
+    return tracer.runInRootSpan({name: 'outer'}, rootSpan => {
       return knex
         .select()
         .from(TABLE_NAME)
@@ -140,7 +140,7 @@ describeInterop<typeof knexTypes>('knex', fixture => {
   });
 
   it('should work with events using ' + version, () => {
-    return tracer.runInRootSpan({ name: 'outer' }, rootSpan => {
+    return tracer.runInRootSpan({name: 'outer'}, rootSpan => {
       return knex
         .select()
         .from(TABLE_NAME)
@@ -171,7 +171,7 @@ describeInterop<typeof knexTypes>('knex', fixture => {
   });
 
   it('should work without events or callback using ' + version, () => {
-    return tracer.runInRootSpan({ name: 'outer' }, rootSpan => {
+    return tracer.runInRootSpan({name: 'outer'}, rootSpan => {
       return knex
         .select()
         .from(TABLE_NAME)
@@ -194,8 +194,8 @@ describeInterop<typeof knexTypes>('knex', fixture => {
   });
 
   it('should perform basic transaction using ' + version, () => {
-    const obj2 = { k: 2, v: 'obj2' };
-    return tracer.runInRootSpan({ name: 'outer' }, rootSpan => {
+    const obj2 = {k: 2, v: 'obj2'};
+    return tracer.runInRootSpan({name: 'outer'}, rootSpan => {
       return knex
         .transaction(trx => {
           knex

--- a/test/plugins/test-trace-mongoose-async-await.ts
+++ b/test/plugins/test-trace-mongoose-async-await.ts
@@ -18,7 +18,7 @@ import * as assert from 'assert';
 import * as mongooseTypes from 'mongoose';
 
 import * as traceTestModule from '../trace';
-import { describeInterop } from '../utils';
+import {describeInterop} from '../utils';
 
 describeInterop<typeof mongooseTypes>('mongoose', fixture => {
   let mongoose: typeof mongooseTypes;
@@ -30,10 +30,10 @@ describeInterop<typeof mongooseTypes>('mongoose', fixture => {
    * Common logic used in multiple tests -- inserts an object into the database.
    * @param doc
    */
-  async function insertTestData(doc: { f1: string; f2: boolean; f3: number }) {
+  async function insertTestData(doc: {f1: string; f2: boolean; f3: number}) {
     const data = new Simple(doc);
     const tracer = traceTestModule.get();
-    await tracer.runInRootSpan({ name: 'insert-test-data' }, async span => {
+    await tracer.runInRootSpan({name: 'insert-test-data'}, async span => {
       assert.ok(tracer.isRealSpan(span));
       await data.save();
       span.endSpan();
@@ -47,8 +47,8 @@ describeInterop<typeof mongooseTypes>('mongoose', fixture => {
     mongoose = fixture.require();
     await mongoose.connect('mongodb://localhost:27017/testdb');
 
-    const { Schema } = mongoose;
-    const simpleSchema = new Schema({ f1: String, f2: Boolean, f3: Number });
+    const {Schema} = mongoose;
+    const simpleSchema = new Schema({f1: String, f2: Boolean, f3: Number});
     Simple = mongoose.model('Simple', simpleSchema);
   });
 
@@ -64,7 +64,7 @@ describeInterop<typeof mongooseTypes>('mongoose', fixture => {
   });
 
   it('Traces creates with async/await', async () => {
-    await insertTestData({ f1: 'val', f2: false, f3: 1729 });
+    await insertTestData({f1: 'val', f2: false, f3: 1729});
     const trace = traceTestModule.getOneTrace(trace =>
       trace.spans.some(span => span.name === 'insert-test-data')
     );
@@ -73,11 +73,11 @@ describeInterop<typeof mongooseTypes>('mongoose', fixture => {
   });
 
   it('Traces queries with async/await', async () => {
-    await insertTestData({ f1: 'sim', f2: false, f3: 1729 });
+    await insertTestData({f1: 'sim', f2: false, f3: 1729});
     const tracer = traceTestModule.get();
-    await tracer.runInRootSpan({ name: 'query-test-data' }, async span => {
+    await tracer.runInRootSpan({name: 'query-test-data'}, async span => {
       assert.ok(tracer.isRealSpan(span));
-      await Simple.findOne({ f1: 'sim' });
+      await Simple.findOne({f1: 'sim'});
       span.endSpan();
     });
     const trace = traceTestModule.getOneTrace(trace =>

--- a/test/test-cls-ah.ts
+++ b/test/test-cls-ah.ts
@@ -18,7 +18,7 @@ import * as assert from 'assert';
 import * as asyncHooksModule from 'async_hooks';
 import * as semver from 'semver';
 
-import { AsyncHooksCLS } from '../src/cls/async-hooks';
+import {AsyncHooksCLS} from '../src/cls/async-hooks';
 
 type AsyncHooksModule = typeof asyncHooksModule;
 
@@ -75,7 +75,7 @@ maybeSkip(describe)('AsyncHooks-based CLS', () => {
           uid: number,
           type: string,
           tid: number,
-          resource: { promise: Promise<void> }
+          resource: {promise: Promise<void>}
         ) => {
           if (type === 'PROMISE') {
             numPromiseInitHookInvocations++;
@@ -149,7 +149,7 @@ maybeSkip(describe)('AsyncHooks-based CLS', () => {
       skip?: boolean;
       fn: () => {};
     }> = [
-      { description: 'a no-op async function', fn: async () => {} },
+      {description: 'a no-op async function', fn: async () => {}},
       {
         description: 'an async function that throws',
         fn: async () => {

--- a/test/test-cls.ts
+++ b/test/test-cls.ts
@@ -15,21 +15,21 @@
  */
 
 import * as assert from 'assert';
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 import * as semver from 'semver';
-import { inspect } from 'util';
+import {inspect} from 'util';
 
-import { TraceCLS, TraceCLSConfig, TraceCLSMechanism } from '../src/cls';
-import { AsyncHooksCLS } from '../src/cls/async-hooks';
-import { AsyncListenerCLS } from '../src/cls/async-listener';
-import { CLS } from '../src/cls/base';
-import { NullCLS } from '../src/cls/null';
-import { SingularCLS } from '../src/cls/singular';
-import { SpanType } from '../src/constants';
-import { createStackTrace, FORCE_NEW } from '../src/util';
+import {TraceCLS, TraceCLSConfig, TraceCLSMechanism} from '../src/cls';
+import {AsyncHooksCLS} from '../src/cls/async-hooks';
+import {AsyncListenerCLS} from '../src/cls/async-listener';
+import {CLS} from '../src/cls/base';
+import {NullCLS} from '../src/cls/null';
+import {SingularCLS} from '../src/cls/singular';
+import {SpanType} from '../src/constants';
+import {createStackTrace, FORCE_NEW} from '../src/util';
 
-import { TestLogger } from './logger';
-import { plan } from './utils';
+import {TestLogger} from './logger';
+import {plan} from './utils';
 
 interface CLSConstructor {
   new (defaultValue: string): CLS<string>;
@@ -233,21 +233,21 @@ describe('Continuation-Local Storage', () => {
       expectedDefaultType: SpanType;
     }> = [
       {
-        config: { mechanism: TraceCLSMechanism.ASYNC_LISTENER },
+        config: {mechanism: TraceCLSMechanism.ASYNC_LISTENER},
         expectedDefaultType: SpanType.UNCORRELATED,
       },
       {
-        config: { mechanism: TraceCLSMechanism.SINGULAR },
+        config: {mechanism: TraceCLSMechanism.SINGULAR},
         expectedDefaultType: SpanType.UNCORRELATED,
       },
       {
-        config: { mechanism: TraceCLSMechanism.NONE },
+        config: {mechanism: TraceCLSMechanism.NONE},
         expectedDefaultType: SpanType.UNCORRELATED,
       },
     ];
     if (asyncAwaitSupported) {
       validTestCases.push({
-        config: { mechanism: TraceCLSMechanism.ASYNC_HOOKS },
+        config: {mechanism: TraceCLSMechanism.ASYNC_HOOKS},
         expectedDefaultType: SpanType.UNCORRELATED,
       });
     }
@@ -261,7 +261,7 @@ describe('Continuation-Local Storage', () => {
             c = new TraceCLS(testCase.config, logger);
             c.enable();
           } catch {
-            c = { disable: () => {} } as TraceCLS;
+            c = {disable: () => {}} as TraceCLS;
           }
         });
 
@@ -306,11 +306,11 @@ describe('Continuation-Local Storage', () => {
 
     const invalidTestCases: TraceCLSConfig[] = asyncAwaitSupported
       ? [
-          { mechanism: 'unknown' } as any, // tslint:disable-line:no-any
+          {mechanism: 'unknown'} as any, // tslint:disable-line:no-any
         ]
       : [
-          { mechanism: 'unknown' } as any, // tslint:disable-line:no-any
-          { mechanism: 'async-hooks' },
+          {mechanism: 'unknown'} as any, // tslint:disable-line:no-any
+          {mechanism: 'async-hooks'},
         ];
 
     for (const testCase of invalidTestCases) {

--- a/test/test-config-plugins.ts
+++ b/test/test-config-plugins.ts
@@ -16,15 +16,15 @@
 
 import * as assert from 'assert';
 
-import { defaultConfig } from '../src/config';
-import { StackdriverTracerComponents } from '../src/trace-api';
-import { PluginLoader, PluginLoaderConfig } from '../src/trace-plugin-loader';
+import {defaultConfig} from '../src/config';
+import {StackdriverTracerComponents} from '../src/trace-api';
+import {PluginLoader, PluginLoaderConfig} from '../src/trace-plugin-loader';
 
 import * as testTraceModule from './trace';
 
 describe('Configuration: Plugins', () => {
   const instrumentedModules = Object.keys(defaultConfig.plugins);
-  let plugins: { [pluginName: string]: string } | null;
+  let plugins: {[pluginName: string]: string} | null;
 
   class ConfigTestPluginLoader extends PluginLoader {
     constructor(
@@ -61,7 +61,7 @@ describe('Configuration: Plugins', () => {
   });
 
   it('should handle empty object', () => {
-    testTraceModule.start({ plugins: {} });
+    testTraceModule.start({plugins: {}});
     assert.ok(plugins);
     assert.strictEqual(
       JSON.stringify(Object.keys(plugins!)),
@@ -73,12 +73,12 @@ describe('Configuration: Plugins', () => {
   });
 
   it('should handle non-object', () => {
-    testTraceModule.start({ plugins: false as {} });
+    testTraceModule.start({plugins: false as {}});
     assert.deepStrictEqual(plugins, {});
   });
 
   it('should overwrite builtin plugins correctly', () => {
-    testTraceModule.start({ plugins: { express: 'foo' } });
+    testTraceModule.start({plugins: {express: 'foo'}});
     assert.ok(plugins);
     assert.strictEqual(
       JSON.stringify(Object.keys(plugins!)),

--- a/test/test-config-priority.ts
+++ b/test/test-config-priority.ts
@@ -17,10 +17,10 @@
 import * as assert from 'assert';
 import * as path from 'path';
 
-import { Trace } from '../src/trace';
-import { StackdriverTracer } from '../src/trace-api';
-import { TraceWriter } from '../src/trace-writer';
-import { TopLevelConfig, Tracing } from '../src/tracing';
+import {Trace} from '../src/trace';
+import {StackdriverTracer} from '../src/trace-api';
+import {TraceWriter} from '../src/trace-writer';
+import {TopLevelConfig, Tracing} from '../src/tracing';
 
 import * as traceTestModule from './trace';
 
@@ -85,7 +85,7 @@ describe('should respect config load order', () => {
     });
 
     it('should order Default -> env config -> start -> env specific', () => {
-      traceTestModule.start({ logLevel: 3, stackTraceLimit: 2 });
+      traceTestModule.start({logLevel: 3, stackTraceLimit: 2});
       const config = getCapturedConfig();
       assert.strictEqual(config.logLevel, 2);
       assert.strictEqual(config.writerConfig.stackTraceLimit, 2);
@@ -109,7 +109,7 @@ describe('should respect config load order', () => {
     });
 
     it('should prefer env to config', () => {
-      traceTestModule.start({ projectId: '1927' });
+      traceTestModule.start({projectId: '1927'});
       const config = getCapturedConfig();
       assert.strictEqual(config.writerConfig.authOptions.projectId, '1729');
     });

--- a/test/test-default-ignore-ah-health.ts
+++ b/test/test-default-ignore-ah-health.ts
@@ -21,7 +21,7 @@ import * as trace from './trace';
 describe('Trace API', () => {
   it('should ignore /_ah/health traces by default', () => {
     const traceApi = trace.start();
-    traceApi.runInRootSpan({ name: 'root', url: '/_ah/health' }, rootSpan => {
+    traceApi.runInRootSpan({name: 'root', url: '/_ah/health'}, rootSpan => {
       assert.strictEqual(rootSpan.type, traceApi.spanTypes.UNSAMPLED);
     });
   });

--- a/test/test-env-log-level.ts
+++ b/test/test-env-log-level.ts
@@ -19,14 +19,14 @@ import * as shimmer from 'shimmer';
 
 import * as logger from '../src/logger';
 
-import { TestLogger } from './logger';
+import {TestLogger} from './logger';
 import * as traceTestModule from './trace';
 
 describe('should respect environment variables', () => {
   let logLevel: string | null = null;
 
   class CaptureLogLevelTestLogger extends TestLogger {
-    constructor(opts: { level: string | false }) {
+    constructor(opts: {level: string | false}) {
       super(opts);
       if (opts.level === false) {
         throw new Error('Unexpected value for opts.level');
@@ -57,7 +57,7 @@ describe('should respect environment variables', () => {
   });
 
   it('should prefer env to config', () => {
-    traceTestModule.start({ logLevel: 2 });
+    traceTestModule.start({logLevel: 2});
     assert.strictEqual(logLevel, logger.LEVELS[4]);
   });
 

--- a/test/test-grpc-async-handler.ts
+++ b/test/test-grpc-async-handler.ts
@@ -17,9 +17,9 @@
 import * as protoLoader from '@grpc/proto-loader';
 import * as grpcModule from 'grpc';
 
-import { Tester, TesterClient } from './test-grpc-proto';
+import {Tester, TesterClient} from './test-grpc-proto';
 import * as traceTestModule from './trace';
-import { describeInterop } from './utils';
+import {describeInterop} from './utils';
 
 type Grpc = typeof grpcModule;
 
@@ -57,17 +57,17 @@ describeInterop<Grpc>('grpc', fixture => {
       server = new grpc.Server();
       server.addService<Tester>(testerService, {
         testUnary: async (call, callback) => {
-          callback(null, { n: 0 });
+          callback(null, {n: 0});
         },
         testClientStream: async (call, callback) => {
-          callback(null, { n: 0 });
+          callback(null, {n: 0});
         },
         testServerStream: async call => {
-          call.write({ n: 0 });
+          call.write({n: 0});
           call.end();
         },
         testBidiStream: async call => {
-          call.write({ n: 0 });
+          call.write({n: 0});
           call.end();
         },
       });
@@ -93,9 +93,9 @@ describeInterop<Grpc>('grpc', fixture => {
 
     it('should work with async unary call handlers', async () => {
       const tracer = traceTestModule.get();
-      await tracer.runInRootSpan({ name: 'client-outer' }, async span => {
+      await tracer.runInRootSpan({name: 'client-outer'}, async span => {
         await new Promise((resolve, reject) =>
-          client.TestUnary({ n: 0 }, (err, res) =>
+          client.TestUnary({n: 0}, (err, res) =>
             err ? reject(err) : resolve()
           )
         );
@@ -112,7 +112,7 @@ describeInterop<Grpc>('grpc', fixture => {
 
     it('should work with async client streaming handlers', async () => {
       const tracer = traceTestModule.get();
-      await tracer.runInRootSpan({ name: 'client-outer' }, async span => {
+      await tracer.runInRootSpan({name: 'client-outer'}, async span => {
         await new Promise((resolve, reject) =>
           client
             .TestClientStream((err, res) => (err ? reject(err) : resolve()))
@@ -131,10 +131,10 @@ describeInterop<Grpc>('grpc', fixture => {
 
     it('should work with async server streaming handlers', async () => {
       const tracer = traceTestModule.get();
-      await tracer.runInRootSpan({ name: 'client-outer' }, async span => {
+      await tracer.runInRootSpan({name: 'client-outer'}, async span => {
         await new Promise((resolve, reject) =>
           client
-            .TestServerStream({ n: 0 })
+            .TestServerStream({n: 0})
             .on('error', reject)
             .on('data', () => {})
             .on('end', resolve)
@@ -152,7 +152,7 @@ describeInterop<Grpc>('grpc', fixture => {
 
     it('should work with async bidi streaming handlers', async () => {
       const tracer = traceTestModule.get();
-      await tracer.runInRootSpan({ name: 'client-outer' }, async span => {
+      await tracer.runInRootSpan({name: 'client-outer'}, async span => {
         await new Promise((resolve, reject) =>
           client
             .TestBidiStream()

--- a/test/test-modules-loaded-before-agent.ts
+++ b/test/test-modules-loaded-before-agent.ts
@@ -19,7 +19,7 @@ import * as shimmer from 'shimmer';
 
 import * as log from '../src/logger';
 
-import { TestLogger } from './logger';
+import {TestLogger} from './logger';
 import * as testTraceModule from './trace';
 
 describe('modules loaded before agent', () => {

--- a/test/test-plugin-loader.ts
+++ b/test/test-plugin-loader.ts
@@ -17,21 +17,21 @@
 import * as assert from 'assert';
 import * as path from 'path';
 
-import { OpenCensusPropagation } from '../src/config';
+import {OpenCensusPropagation} from '../src/config';
 import {
   PluginLoader,
   PluginLoaderState,
   PluginWrapper,
 } from '../src/trace-plugin-loader';
-import { alwaysTrace } from '../src/tracing-policy';
+import {alwaysTrace} from '../src/tracing-policy';
 
-import { TestLogger } from './logger';
-import { getBaseConfig, NoPropagation } from './utils';
+import {TestLogger} from './logger';
+import {getBaseConfig, NoPropagation} from './utils';
 
 export interface SimplePluginLoaderConfig {
   // An object which contains paths to files that should be loaded as plugins
   // upon loading a module with a given name.
-  plugins: { [pluginName: string]: string };
+  plugins: {[pluginName: string]: string};
 }
 
 const SEARCH_PATH = `${__dirname}/fixtures/loader/node_modules`;
@@ -45,8 +45,8 @@ describe('Trace Plugin Loader', () => {
   let logger: TestLogger;
   const makePluginLoader = (config: SimplePluginLoaderConfig) => {
     return new PluginLoader(
-      Object.assign({ tracerConfig: getBaseConfig() }, config),
-      { tracePolicy: alwaysTrace(), logger, propagation: new NoPropagation() }
+      Object.assign({tracerConfig: getBaseConfig()}, config),
+      {tracePolicy: alwaysTrace(), logger, propagation: new NoPropagation()}
     );
   };
 
@@ -64,7 +64,7 @@ describe('Trace Plugin Loader', () => {
   describe('interface', () => {
     describe('state', () => {
       it('returns NO_HOOK when first called', () => {
-        const pluginLoader = makePluginLoader({ plugins: {} });
+        const pluginLoader = makePluginLoader({plugins: {}});
         assert.strictEqual(pluginLoader.state, PluginLoaderState.NO_HOOK);
       });
     });
@@ -72,7 +72,7 @@ describe('Trace Plugin Loader', () => {
     describe('activate', () => {
       it('transitions from NO_HOOK to ACTIVATED, enabling require hook', () => {
         let requireHookCalled = false;
-        const pluginLoader = makePluginLoader({ plugins: {} });
+        const pluginLoader = makePluginLoader({plugins: {}});
         // TODO(kjin): Stop using index properties.
         pluginLoader['enableRequireHook'] = () => (requireHookCalled = true);
         pluginLoader.activate();
@@ -83,7 +83,7 @@ describe('Trace Plugin Loader', () => {
 
       it('throws if internal state is already ACTIVATED', () => {
         let requireHookCalled = false;
-        const pluginLoader = makePluginLoader({ plugins: {} }).activate();
+        const pluginLoader = makePluginLoader({plugins: {}}).activate();
         assert.strictEqual(pluginLoader.state, PluginLoaderState.ACTIVATED);
         // TODO(kjin): Stop using index properties.
         pluginLoader['enableRequireHook'] = () => (requireHookCalled = true);
@@ -96,7 +96,7 @@ describe('Trace Plugin Loader', () => {
         // There is currently no reason to transition back and forth.
         // This behavior may change in the future.
         let requireHookCalled = false;
-        const pluginLoader = makePluginLoader({ plugins: {} })
+        const pluginLoader = makePluginLoader({plugins: {}})
           .activate()
           .deactivate();
         assert.strictEqual(pluginLoader.state, PluginLoaderState.DEACTIVATED);
@@ -123,7 +123,7 @@ describe('Trace Plugin Loader', () => {
       }
 
       it('transitions state from ACTIVATED to DEACTIVATED, unapplying plugins', () => {
-        const pluginLoader = makePluginLoader({ plugins: {} }).activate();
+        const pluginLoader = makePluginLoader({plugins: {}}).activate();
         assert.strictEqual(pluginLoader.state, PluginLoaderState.ACTIVATED);
         const plugin = new TestPluginWrapper();
         // TODO(kjin): Stop using index properties.
@@ -141,13 +141,13 @@ describe('Trace Plugin Loader', () => {
       it('parses module strings', () => {
         const p = PluginLoader.parseModuleString;
         const sep = path.sep;
-        assert.deepStrictEqual(p('m'), { name: 'm', file: '' });
-        assert.deepStrictEqual(p('m/f'), { name: 'm', file: 'f' });
-        assert.deepStrictEqual(p('m/d/f'), { name: 'm', file: 'd/f' });
-        assert.deepStrictEqual(p(`m\\d\\f`), { name: 'm', file: 'd/f' });
-        assert.deepStrictEqual(p(`@o\\m\\d\\f`), { name: '@o/m', file: 'd/f' });
-        assert.deepStrictEqual(p('@o/m/d/f'), { name: '@o/m', file: 'd/f' });
-        assert.deepStrictEqual(p('@o/m/d/f'), { name: '@o/m', file: 'd/f' });
+        assert.deepStrictEqual(p('m'), {name: 'm', file: ''});
+        assert.deepStrictEqual(p('m/f'), {name: 'm', file: 'f'});
+        assert.deepStrictEqual(p('m/d/f'), {name: 'm', file: 'd/f'});
+        assert.deepStrictEqual(p(`m\\d\\f`), {name: 'm', file: 'd/f'});
+        assert.deepStrictEqual(p(`@o\\m\\d\\f`), {name: '@o/m', file: 'd/f'});
+        assert.deepStrictEqual(p('@o/m/d/f'), {name: '@o/m', file: 'd/f'});
+        assert.deepStrictEqual(p('@o/m/d/f'), {name: '@o/m', file: 'd/f'});
       });
     });
   });
@@ -165,21 +165,21 @@ describe('Trace Plugin Loader', () => {
 
     it(`doesn't patch before activation`, () => {
       const loader = makePluginLoader({
-        plugins: { 'small-number': 'plugin-small-number' },
+        plugins: {'small-number': 'plugin-small-number'},
       });
       assert.strictEqual(require('small-number').value, 0);
       loader.deactivate();
     });
 
     it(`doesn't patch modules for which plugins aren't specified`, () => {
-      const loader = makePluginLoader({ plugins: {} }).activate();
+      const loader = makePluginLoader({plugins: {}}).activate();
       assert.strictEqual(require('small-number').value, 0);
       loader.deactivate();
     });
 
     it('patches modules when activated, with no plugin file field specifying the main file', () => {
       const loader = makePluginLoader({
-        plugins: { 'small-number': 'plugin-small-number' },
+        plugins: {'small-number': 'plugin-small-number'},
       }).activate();
       assert.strictEqual(require('small-number').value, 1);
       // Make sure requiring doesn't patch twice
@@ -193,7 +193,7 @@ describe('Trace Plugin Loader', () => {
 
     it('accepts absolute paths in configuration', () => {
       const loader = makePluginLoader({
-        plugins: { 'small-number': `${SEARCH_PATH}/plugin-small-number` },
+        plugins: {'small-number': `${SEARCH_PATH}/plugin-small-number`},
       }).activate();
       assert.strictEqual(require('small-number').value, 1);
       assert.strictEqual(
@@ -205,7 +205,7 @@ describe('Trace Plugin Loader', () => {
 
     it('unpatches modules when deactivated', () => {
       const loader = makePluginLoader({
-        plugins: { 'small-number': 'plugin-small-number' },
+        plugins: {'small-number': 'plugin-small-number'},
       }).activate();
       require('small-number');
       loader.deactivate();
@@ -219,7 +219,7 @@ describe('Trace Plugin Loader', () => {
 
     it('intercepts and patches internal files', () => {
       const loader = makePluginLoader({
-        plugins: { 'large-number': 'plugin-large-number' },
+        plugins: {'large-number': 'plugin-large-number'},
       }).activate();
       assert.strictEqual(require('large-number'), 2e100);
       loader.deactivate();
@@ -228,9 +228,9 @@ describe('Trace Plugin Loader', () => {
     ['http', 'url', '[core]'].forEach(key => {
       it(`intercepts and patches core modules with key "${key}"`, () => {
         const loader = makePluginLoader({
-          plugins: { [key]: 'plugin-core' },
+          plugins: {[key]: 'plugin-core'},
         }).activate();
-        const input = { protocol: 'http:', host: 'hi' };
+        const input = {protocol: 'http:', host: 'hi'};
         assert.strictEqual(require('url').format(input), 'patched-value');
         loader.deactivate();
         assert.strictEqual(require('url').format(input), 'http://hi');
@@ -244,7 +244,7 @@ describe('Trace Plugin Loader', () => {
 
     it(`doesn't load plugins with falsey paths`, () => {
       const loader = makePluginLoader({
-        plugins: { 'small-number': '' },
+        plugins: {'small-number': ''},
       }).activate();
       assert.strictEqual(require('small-number').value, 0);
       loader.deactivate();
@@ -252,7 +252,7 @@ describe('Trace Plugin Loader', () => {
 
     it('uses version ranges to determine how to patch internals', () => {
       const loader = makePluginLoader({
-        plugins: { 'my-version': 'plugin-my-version-1' },
+        plugins: {'my-version': 'plugin-my-version-1'},
       }).activate();
       assert.strictEqual(require('my-version-1.0'), '1.0.0-patched');
       // v1.1 has different internals.
@@ -268,7 +268,7 @@ describe('Trace Plugin Loader', () => {
 
     it('patches pre-releases, but warns', () => {
       const loader = makePluginLoader({
-        plugins: { 'my-version': 'plugin-my-version-1' },
+        plugins: {'my-version': 'plugin-my-version-1'},
       }).activate();
       assert.strictEqual(require('my-version-1.0-pre'), '1.0.0-pre-patched');
       assert.strictEqual(
@@ -280,7 +280,7 @@ describe('Trace Plugin Loader', () => {
 
     it('throws when the plugin throws', () => {
       const loader = makePluginLoader({
-        plugins: { 'my-version': 'plugin-my-version-2' },
+        plugins: {'my-version': 'plugin-my-version-2'},
       }).activate();
       let threw = false;
       try {
@@ -294,7 +294,7 @@ describe('Trace Plugin Loader', () => {
 
     it('warns when a module is patched by a non-conformant plugin', () => {
       const loader = makePluginLoader({
-        plugins: { '[core]': 'plugin-core' },
+        plugins: {'[core]': 'plugin-core'},
       }).activate();
       // Reasons for possible warnings issued are listed as comments.
       require('crypto'); // neither patch nor intercept

--- a/test/test-span-data.ts
+++ b/test/test-span-data.ts
@@ -16,19 +16,15 @@
 
 import * as assert from 'assert';
 
-import { Constants, SpanType } from '../src/constants';
-import { BaseSpanData, ChildSpanData, RootSpanData } from '../src/span-data';
-import { Trace } from '../src/trace';
-import { TraceLabels } from '../src/trace-labels';
-import {
-  traceWriter,
-  TraceWriter,
-  TraceWriterConfig,
-} from '../src/trace-writer';
+import {Constants, SpanType} from '../src/constants';
+import {BaseSpanData, ChildSpanData, RootSpanData} from '../src/span-data';
+import {Trace} from '../src/trace';
+import {TraceLabels} from '../src/trace-labels';
+import {traceWriter, TraceWriter, TraceWriterConfig} from '../src/trace-writer';
 
-import { TestLogger } from './logger';
+import {TestLogger} from './logger';
 import * as traceAgentModule from './trace';
-import { wait } from './utils';
+import {wait} from './utils';
 
 describe('SpanData', () => {
   class CaptureSpanTraceWriter extends TraceWriter {
@@ -57,7 +53,7 @@ describe('SpanData', () => {
   });
 
   beforeEach(() => {
-    trace = { projectId: '0', traceId: 'trace-id', spans: [] };
+    trace = {projectId: '0', traceId: 'trace-id', spans: []};
     capturedTrace = null;
   });
 
@@ -139,7 +135,7 @@ describe('SpanData', () => {
       const spanData = new CommonSpanData(trace, 'name', '0', 0);
       spanData.addLabel('key', 'value');
       spanData.addLabel('id', 42);
-      spanData.addLabel('obj', { a: true });
+      spanData.addLabel('obj', {a: true});
       spanData.addLabel('sym', Symbol('a'));
       delete spanData.span.labels[TraceLabels.STACK_TRACE_DETAILS_KEY];
       assert.deepStrictEqual(spanData.span.labels, {

--- a/test/test-trace-api-none-cls.ts
+++ b/test/test-trace-api-none-cls.ts
@@ -16,11 +16,11 @@
 
 import * as assert from 'assert';
 
-import { SpanType } from '../src/constants';
-import { Tracer } from '../src/plugin-types';
+import {SpanType} from '../src/constants';
+import {Tracer} from '../src/plugin-types';
 
 import * as testTraceModule from './trace';
-import { asChildSpanData, asRootSpanData } from './utils';
+import {asChildSpanData, asRootSpanData} from './utils';
 
 const identity = <T>(x: T) => x;
 
@@ -36,7 +36,7 @@ describe('Custom Trace API with CLS disabled', () => {
   });
 
   beforeEach(() => {
-    traceApi = testTraceModule.start({ clsMechanism: 'none' });
+    traceApi = testTraceModule.start({clsMechanism: 'none'});
   });
 
   afterEach(() => {
@@ -44,9 +44,9 @@ describe('Custom Trace API with CLS disabled', () => {
   });
 
   it('should allow root spans to be created without constraints', () => {
-    traceApi.runInRootSpan({ name: 'root1' }, root1 => {
+    traceApi.runInRootSpan({name: 'root1'}, root1 => {
       assert.strictEqual(root1.type, SpanType.ROOT);
-      traceApi.runInRootSpan({ name: 'root2' }, root2 => {
+      traceApi.runInRootSpan({name: 'root2'}, root2 => {
         assert.strictEqual(root2.type, SpanType.ROOT);
         assert.notStrictEqual(
           asRootSpanData(root2).trace.traceId,
@@ -60,9 +60,9 @@ describe('Custom Trace API with CLS disabled', () => {
 
   it('should allow child spans to be created using root span API', () => {
     const root = asRootSpanData(
-      traceApi.runInRootSpan({ name: 'root' }, identity)
+      traceApi.runInRootSpan({name: 'root'}, identity)
     );
-    const child = asChildSpanData(root.createChildSpan({ name: 'child' }));
+    const child = asChildSpanData(root.createChildSpan({name: 'child'}));
     assert.strictEqual(child.span.parentSpanId, root.span.spanId);
     assert.strictEqual(child.trace.traceId, root.trace.traceId);
     child.endSpan();
@@ -71,9 +71,9 @@ describe('Custom Trace API with CLS disabled', () => {
 
   it('should create phantom child spans thru trace API', () => {
     const root = asRootSpanData(
-      traceApi.runInRootSpan({ name: 'root' }, identity)
+      traceApi.runInRootSpan({name: 'root'}, identity)
     );
-    const child = traceApi.createChildSpan({ name: 'child' });
+    const child = traceApi.createChildSpan({name: 'child'});
     assert.strictEqual(child.type, SpanType.UNCORRELATED);
     child.endSpan();
     root.endSpan();

--- a/test/test-trace-api.ts
+++ b/test/test-trace-api.ts
@@ -16,7 +16,7 @@
 
 import * as assert from 'assert';
 
-import { cls, TraceCLS, TraceCLSMechanism } from '../src/cls';
+import {cls, TraceCLS, TraceCLSMechanism} from '../src/cls';
 import {
   defaultConfig,
   GetHeaderFunction as HeaderGetter,
@@ -25,19 +25,19 @@ import {
   SetHeaderFunction as HeaderSetter,
   TracePolicy,
 } from '../src/config';
-import { SpanType } from '../src/constants';
+import {SpanType} from '../src/constants';
 import {
   StackdriverTracer,
   StackdriverTracerComponents,
   StackdriverTracerConfig,
 } from '../src/trace-api';
-import { traceWriter } from '../src/trace-writer';
-import { alwaysTrace, neverTrace } from '../src/tracing-policy';
-import { FORCE_NEW, TraceContext } from '../src/util';
+import {traceWriter} from '../src/trace-writer';
+import {alwaysTrace, neverTrace} from '../src/tracing-policy';
+import {FORCE_NEW, TraceContext} from '../src/util';
 
-import { TestLogger } from './logger';
+import {TestLogger} from './logger';
 import * as testTraceModule from './trace';
-import { getBaseConfig, NoPropagation } from './utils';
+import {getBaseConfig, NoPropagation} from './utils';
 
 describe('Trace Interface', () => {
   const logger = new TestLogger();
@@ -62,13 +62,11 @@ describe('Trace Interface', () => {
 
   before(() => {
     testTraceModule.setCLSForTest(TraceCLS);
-    cls
-      .create({ mechanism: TraceCLSMechanism.ASYNC_LISTENER }, logger)
-      .enable();
+    cls.create({mechanism: TraceCLSMechanism.ASYNC_LISTENER}, logger).enable();
     return traceWriter
       .create(
         Object.assign(
-          { [FORCE_NEW]: true, authOptions: { projectId: 'project-1' } },
+          {[FORCE_NEW]: true, authOptions: {projectId: 'project-1'}},
           defaultConfig
         ),
         logger
@@ -94,8 +92,8 @@ describe('Trace Interface', () => {
 
     it('should produce real child spans with createChildSpan', () => {
       const traceAPI = createTraceAgent();
-      traceAPI.runInRootSpan({ name: 'root' }, rootSpan => {
-        const childSpan = traceAPI.createChildSpan({ name: 'sub' });
+      traceAPI.runInRootSpan({name: 'root'}, rootSpan => {
+        const childSpan = traceAPI.createChildSpan({name: 'sub'});
         childSpan.addLabel('key', 'val');
         childSpan.endSpan();
         rootSpan.endSpan();
@@ -112,8 +110,8 @@ describe('Trace Interface', () => {
 
     it('should produce real child spans through root span API', () => {
       const traceAPI = createTraceAgent();
-      traceAPI.runInRootSpan({ name: 'root' }, rootSpan => {
-        const childSpan = rootSpan.createChildSpan({ name: 'sub' });
+      traceAPI.runInRootSpan({name: 'root'}, rootSpan => {
+        const childSpan = rootSpan.createChildSpan({name: 'sub'});
         childSpan.addLabel('key', 'val');
         childSpan.endSpan();
         rootSpan.endSpan();
@@ -131,7 +129,7 @@ describe('Trace Interface', () => {
 
     it('should produce real root spans with runInRootSpan', () => {
       const traceAPI = createTraceAgent();
-      const result = traceAPI.runInRootSpan({ name: 'root' }, rootSpan => {
+      const result = traceAPI.runInRootSpan({name: 'root'}, rootSpan => {
         rootSpan.addLabel('key', 'val');
         rootSpan.endSpan();
         return 'result';
@@ -146,10 +144,10 @@ describe('Trace Interface', () => {
 
     it('should allow sequential root spans', () => {
       const traceAPI = createTraceAgent();
-      traceAPI.runInRootSpan({ name: 'root1' }, rootSpan => {
+      traceAPI.runInRootSpan({name: 'root1'}, rootSpan => {
         rootSpan.endSpan();
       });
-      traceAPI.runInRootSpan({ name: 'root2' }, rootSpan => {
+      traceAPI.runInRootSpan({name: 'root2'}, rootSpan => {
         rootSpan.endSpan();
       });
       assert.strictEqual(testTraceModule.getTraces().length, 2);
@@ -157,8 +155,8 @@ describe('Trace Interface', () => {
 
     it('should not allow nested root spans', () => {
       const traceAPI = createTraceAgent();
-      traceAPI.runInRootSpan({ name: 'root1' }, rootSpan => {
-        traceAPI.runInRootSpan({ name: 'root2' }, notRootSpan => {
+      traceAPI.runInRootSpan({name: 'root1'}, rootSpan => {
+        traceAPI.runInRootSpan({name: 'root2'}, notRootSpan => {
           assert.strictEqual(notRootSpan.type, SpanType.UNCORRELATED);
           notRootSpan.endSpan();
         });
@@ -174,7 +172,7 @@ describe('Trace Interface', () => {
         traceAPI.getCurrentRootSpan().type,
         SpanType.UNCORRELATED
       );
-      traceAPI.runInRootSpan({ name: 'root' }, rootSpan => {
+      traceAPI.runInRootSpan({name: 'root'}, rootSpan => {
         assert.strictEqual(traceAPI.getCurrentRootSpan(), rootSpan);
         rootSpan.endSpan();
       });
@@ -185,15 +183,15 @@ describe('Trace Interface', () => {
         spansPerTraceSoftLimit: 10,
         spansPerTraceHardLimit: 20,
       });
-      tracer.runInRootSpan({ name: 'root' }, rootSpan => {
+      tracer.runInRootSpan({name: 'root'}, rootSpan => {
         for (let i = 0; i < 10; i++) {
-          tracer.createChildSpan({ name: `span-${i}` }).endSpan();
+          tracer.createChildSpan({name: `span-${i}`}).endSpan();
         }
         assert.strictEqual(logger.getNumLogsWith('error', '[span-9]'), 1);
         for (let i = 0; i < 9; i++) {
-          tracer.createChildSpan({ name: `span-${i + 10}` }).endSpan();
+          tracer.createChildSpan({name: `span-${i + 10}`}).endSpan();
         }
-        const child = tracer.createChildSpan({ name: `span-19` });
+        const child = tracer.createChildSpan({name: `span-19`});
         assert.ok(!tracer.isRealSpan(child));
         assert.strictEqual(logger.getNumLogsWith('error', '[span-19]'), 1);
         rootSpan.endSpan();
@@ -207,7 +205,7 @@ describe('Trace Interface', () => {
 
     it('should return the appropriate context ID', () => {
       const traceAPI = createTraceAgent();
-      traceAPI.runInRootSpan({ name: 'root' }, rootSpan => {
+      traceAPI.runInRootSpan({name: 'root'}, rootSpan => {
         const id = traceAPI.getCurrentContextId();
         assert.ok(rootSpan.getTraceContext());
         assert.strictEqual(id, rootSpan.getTraceContext()!.traceId);
@@ -218,8 +216,8 @@ describe('Trace Interface', () => {
     });
 
     it('should return a context ID even if in an untraced request', () => {
-      const traceAPI = createTraceAgent({}, { tracePolicy: neverTrace() });
-      traceAPI.runInRootSpan({ name: '' }, rootSpan => {
+      const traceAPI = createTraceAgent({}, {tracePolicy: neverTrace()});
+      traceAPI.runInRootSpan({name: ''}, rootSpan => {
         assert.strictEqual(rootSpan.type, SpanType.UNSAMPLED);
         assert.notStrictEqual(traceAPI.getCurrentContextId(), null);
         assert.ok(rootSpan.getTraceContext());
@@ -251,14 +249,14 @@ describe('Trace Interface', () => {
         }
       }
       const tracePolicy = new CaptureOptionsTracePolicy();
-      const traceAPI = createTraceAgent({}, { tracePolicy });
+      const traceAPI = createTraceAgent({}, {tracePolicy});
       // All params present
       {
         const rootSpanOptions = {
           name: 'root',
           url: 'foo',
           method: 'bar',
-          traceContext: { traceId: '1', spanId: '2', options: 1 },
+          traceContext: {traceId: '1', spanId: '2', options: 1},
         };
         const beforeRootSpan = Date.now();
         traceAPI.runInRootSpan(rootSpanOptions, rootSpan => {
@@ -282,7 +280,7 @@ describe('Trace Interface', () => {
       tracePolicy.capturedShouldTraceParam = null;
       // Limited params present
       {
-        const rootSpanOptions = { name: 'root' };
+        const rootSpanOptions = {name: 'root'};
         traceAPI.runInRootSpan(rootSpanOptions, rootSpan => {
           assert.strictEqual(rootSpan.type, SpanType.UNSAMPLED);
           rootSpan.endSpan();
@@ -298,15 +296,15 @@ describe('Trace Interface', () => {
 
     it('should expose methods for trace context header propagation', () => {
       class TestPropagation implements OpenCensusPropagation {
-        extract({ getHeader }: HeaderGetter) {
-          return { traceId: getHeader('a') as string, spanId: '0', options: 1 };
+        extract({getHeader}: HeaderGetter) {
+          return {traceId: getHeader('a') as string, spanId: '0', options: 1};
         }
-        inject({ setHeader }: HeaderSetter, traceContext: TraceContext) {
+        inject({setHeader}: HeaderSetter, traceContext: TraceContext) {
           setHeader(traceContext.traceId, 'y');
         }
       }
       const propagation = new TestPropagation();
-      const tracer = createTraceAgent({}, { propagation });
+      const tracer = createTraceAgent({}, {propagation});
       const result = tracer.propagation.extract(s => `${s}${s}`);
       assert.deepStrictEqual(result, {
         traceId: 'aa',
@@ -320,7 +318,7 @@ describe('Trace Interface', () => {
           assert.strictEqual(value, 'y');
           setHeaderCalled = true;
         },
-        { traceId: 'x', spanId: '0', options: 1 }
+        {traceId: 'x', spanId: '0', options: 1}
       );
       assert.ok(setHeaderCalled);
     });
@@ -343,7 +341,7 @@ describe('Trace Interface', () => {
         createTraceAgent().runInRootSpan(
           {
             name: 'root1',
-            traceContext: { traceId: '123456', spanId: '667', options: 1 },
+            traceContext: {traceId: '123456', spanId: '667', options: 1},
           },
           rootSpan => {
             rootSpan.endSpan();
@@ -358,7 +356,7 @@ describe('Trace Interface', () => {
       }
       // Generate a trace context
       {
-        createTraceAgent().runInRootSpan({ name: 'root2' }, rootSpan => {
+        createTraceAgent().runInRootSpan({name: 'root2'}, rootSpan => {
           rootSpan.endSpan();
         });
         // The trace ID will not randomly be 123456
@@ -372,8 +370,8 @@ describe('Trace Interface', () => {
     });
 
     it('should trace if no option flags are provided', () => {
-      createTraceAgent({ enhancedDatabaseReporting: false }).runInRootSpan(
-        { name: 'root', traceContext: { traceId: '123456', spanId: '667' } },
+      createTraceAgent({enhancedDatabaseReporting: false}).runInRootSpan(
+        {name: 'root', traceContext: {traceId: '123456', spanId: '667'}},
         rootSpan => {
           rootSpan.endSpan();
         }
@@ -388,13 +386,13 @@ describe('Trace Interface', () => {
       it('should behave as expected', () => {
         const fakeTraceId = 'ffeeddccbbaa99887766554433221100';
         const traceApi = createTraceAgent();
-        const tracedContext = { traceId: fakeTraceId, spanId: '0', options: 1 };
+        const tracedContext = {traceId: fakeTraceId, spanId: '0', options: 1};
         const untracedContext = {
           traceId: fakeTraceId,
           spanId: '0',
           options: 0,
         };
-        const unspecifiedContext = { traceId: fakeTraceId, spanId: '0' };
+        const unspecifiedContext = {traceId: fakeTraceId, spanId: '0'};
         assert.deepStrictEqual(
           traceApi.getResponseTraceContext(tracedContext, true),
           tracedContext

--- a/test/test-trace-cluster.ts
+++ b/test/test-trace-cluster.ts
@@ -17,11 +17,11 @@
 import * as assert from 'assert';
 import axiosModule from 'axios';
 import * as cluster from 'cluster';
-import { Server } from 'http';
-import { AddressInfo } from 'net';
+import {Server} from 'http';
+import {AddressInfo} from 'net';
 
 import * as cls from '../src/cls';
-import { express_4 as expressModule } from '../src/plugins/types';
+import {express_4 as expressModule} from '../src/plugins/types';
 
 import * as testTraceModule from './trace';
 import {
@@ -69,13 +69,11 @@ describe('test-trace-cluster', () => {
       const port = (server.address() as AddressInfo).port;
 
       let recordedTime = Date.now();
-      await testTraceModule
-        .get()
-        .runInRootSpan({ name: 'outer' }, async span => {
-          assert.ok(span);
-          await axios.get(`http://localhost:${port}`);
-          span!.endSpan();
-        });
+      await testTraceModule.get().runInRootSpan({name: 'outer'}, async span => {
+        assert.ok(span);
+        await axios.get(`http://localhost:${port}`);
+        span!.endSpan();
+      });
       recordedTime = Date.now() - recordedTime;
       const serverSpan = testTraceModule.getOneSpan(isServerSpan);
       assertSpanDuration(serverSpan, [DEFAULT_SPAN_DURATION, recordedTime]);

--- a/test/test-trace-hapi-tails.ts
+++ b/test/test-trace-hapi-tails.ts
@@ -19,9 +19,9 @@ import axiosModule from 'axios';
 import * as semver from 'semver';
 
 import * as testTraceModule from './trace';
-import { assertSpanDuration, wait } from './utils';
-import { Hapi17 } from './web-frameworks/hapi17';
-import { Hapi12, Hapi15, Hapi16, Hapi8 } from './web-frameworks/hapi8_16';
+import {assertSpanDuration, wait} from './utils';
+import {Hapi17} from './web-frameworks/hapi17';
+import {Hapi12, Hapi15, Hapi16, Hapi8} from './web-frameworks/hapi8_16';
 
 // The list of web frameworks to test.
 const FRAMEWORKS = [Hapi12, Hapi15, Hapi16, Hapi8, Hapi17];
@@ -68,7 +68,7 @@ describe('Web framework tracing', () => {
             fn: async () => {
               const child = testTraceModule
                 .get()
-                .createChildSpan({ name: 'my-tail-work' });
+                .createChildSpan({name: 'my-tail-work'});
               await wait(100);
               child.endSpan();
             },
@@ -90,7 +90,7 @@ describe('Web framework tracing', () => {
           // Hit the server.
           await testTraceModule
             .get()
-            .runInRootSpan({ name: 'outer' }, async span => {
+            .runInRootSpan({name: 'outer'}, async span => {
               await axios.get(`http://localhost:${port}/tail`);
               span.endSpan();
             });

--- a/test/test-trace-policy.ts
+++ b/test/test-trace-policy.ts
@@ -16,7 +16,7 @@
 
 import * as assert from 'assert';
 
-import { RequestDetails } from '../src/config';
+import {RequestDetails} from '../src/config';
 import {
   BuiltinTracePolicy,
   TraceContextHeaderBehavior,
@@ -59,7 +59,7 @@ class TracePolicyForTest extends BuiltinTracePolicy {
   shouldTraceForTest(requestDetails: Partial<RequestDetails>): boolean {
     return this.shouldTrace(
       Object.assign(
-        { timestamp: 0, url: '', method: '', traceContext, options: {} },
+        {timestamp: 0, url: '', method: '', traceContext, options: {}},
         requestDetails
       )
     );
@@ -85,8 +85,8 @@ describe('TracePolicy', () => {
     });
 
     it('should allow non-filtered urls', () => {
-      const policy = new TracePolicyForTest({ ignoreUrls: ['/_ah/health'] });
-      assert.ok(policy.shouldTraceForTest({ url: '/_ah/background' }));
+      const policy = new TracePolicyForTest({ignoreUrls: ['/_ah/health']});
+      assert.ok(policy.shouldTraceForTest({url: '/_ah/background'}));
     });
   });
 
@@ -95,12 +95,12 @@ describe('TracePolicy', () => {
       const policy = new TracePolicyForTest({
         ignoreMethods: ['method1', 'method2'],
       });
-      assert.ok(!policy.shouldTraceForTest({ method: 'method1' }));
-      assert.ok(!policy.shouldTraceForTest({ method: 'method2' }));
+      assert.ok(!policy.shouldTraceForTest({method: 'method1'}));
+      assert.ok(!policy.shouldTraceForTest({method: 'method2'}));
     });
 
     it('should allow non-filtered methods', () => {
-      const policy = new TracePolicyForTest({ ignoreMethods: ['method'] });
+      const policy = new TracePolicyForTest({ignoreMethods: ['method']});
       assert.ok(
         policy.shouldTraceForTest({
           method: 'method1',
@@ -118,19 +118,19 @@ describe('TracePolicy', () => {
       it('should ignore options bit', () => {
         assert.ok(
           policy.shouldTraceForTest({
-            traceContext: { traceId: '0', spanId: '0', options: 1 },
+            traceContext: {traceId: '0', spanId: '0', options: 1},
           })
         );
         assert.ok(
           policy.shouldTraceForTest({
-            traceContext: { traceId: '0', spanId: '0', options: 0 },
+            traceContext: {traceId: '0', spanId: '0', options: 0},
           })
         );
       });
 
       it('should not require that header exists', () => {
-        assert.ok(policy.shouldTraceForTest({ traceContext: null }));
-        assert.ok(policy.shouldTraceForTest({ traceContext: undefined }));
+        assert.ok(policy.shouldTraceForTest({traceContext: null}));
+        assert.ok(policy.shouldTraceForTest({traceContext: undefined}));
       });
     });
 
@@ -142,19 +142,19 @@ describe('TracePolicy', () => {
       it('should respect options bit', () => {
         assert.ok(
           policy.shouldTraceForTest({
-            traceContext: { traceId: '0', spanId: '0', options: 1 },
+            traceContext: {traceId: '0', spanId: '0', options: 1},
           })
         );
         assert.ok(
           !policy.shouldTraceForTest({
-            traceContext: { traceId: '0', spanId: '0', options: 0 },
+            traceContext: {traceId: '0', spanId: '0', options: 0},
           })
         );
       });
 
       it('should require that header exists', () => {
-        assert.ok(!policy.shouldTraceForTest({ traceContext: null }));
-        assert.ok(!policy.shouldTraceForTest({ traceContext: undefined }));
+        assert.ok(!policy.shouldTraceForTest({traceContext: null}));
+        assert.ok(!policy.shouldTraceForTest({traceContext: undefined}));
       });
     });
 
@@ -166,19 +166,19 @@ describe('TracePolicy', () => {
       it('should respect options bit', () => {
         assert.ok(
           policy.shouldTraceForTest({
-            traceContext: { traceId: '0', spanId: '0', options: 1 },
+            traceContext: {traceId: '0', spanId: '0', options: 1},
           })
         );
         assert.ok(
           !policy.shouldTraceForTest({
-            traceContext: { traceId: '0', spanId: '0', options: 0 },
+            traceContext: {traceId: '0', spanId: '0', options: 0},
           })
         );
       });
 
       it('should not require that header exists', () => {
-        assert.ok(policy.shouldTraceForTest({ traceContext: null }));
-        assert.ok(policy.shouldTraceForTest({ traceContext: undefined }));
+        assert.ok(policy.shouldTraceForTest({traceContext: null}));
+        assert.ok(policy.shouldTraceForTest({traceContext: undefined}));
       });
     });
   });
@@ -188,7 +188,7 @@ describe('TracePolicy', () => {
     const testCases = [0.1, 0.5, 1, 10, 50, 150, 200, 500, 1000];
     for (const testCase of testCases) {
       it(`should throttle traces when samplingRate = ` + testCase, () => {
-        const policy = new TracePolicyForTest({ samplingRate: testCase });
+        const policy = new TracePolicyForTest({samplingRate: testCase});
         const expected = NUM_SECONDS * testCase;
         let actual = 0;
         const start = Date.now();
@@ -197,7 +197,7 @@ describe('TracePolicy', () => {
           timestamp < start + 1000 * NUM_SECONDS;
           timestamp++
         ) {
-          if (policy.shouldTraceForTest({ timestamp })) {
+          if (policy.shouldTraceForTest({timestamp})) {
             actual++;
           }
         }
@@ -213,11 +213,11 @@ describe('TracePolicy', () => {
     }
 
     it('should always sample when samplingRate = 0', () => {
-      const policy = new TracePolicyForTest({ samplingRate: 0 });
+      const policy = new TracePolicyForTest({samplingRate: 0});
       let numSamples = 0;
       const start = Date.now();
       for (let timestamp = start; timestamp < start + 1000; timestamp++) {
-        if (policy.shouldTraceForTest({ timestamp })) {
+        if (policy.shouldTraceForTest({timestamp})) {
           numSamples++;
         }
       }
@@ -225,11 +225,11 @@ describe('TracePolicy', () => {
     });
 
     it('should never sample when samplingRate < 0', () => {
-      const policy = new TracePolicyForTest({ samplingRate: -1 });
+      const policy = new TracePolicyForTest({samplingRate: -1});
       let numSamples = 0;
       const start = Date.now();
       for (let timestamp = start; timestamp < start + 1000; timestamp++) {
-        if (policy.shouldTraceForTest({ timestamp })) {
+        if (policy.shouldTraceForTest({timestamp})) {
           numSamples++;
         }
       }

--- a/test/test-trace-uncaught-exception.ts
+++ b/test/test-trace-uncaught-exception.ts
@@ -16,11 +16,11 @@
 
 import * as assert from 'assert';
 
-import { Logger } from '../src/logger';
-import { Trace } from '../src/trace';
-import { TraceWriterConfig } from '../src/trace-writer';
+import {Logger} from '../src/logger';
+import {Trace} from '../src/trace';
+import {TraceWriterConfig} from '../src/trace-writer';
 
-import { TestLogger } from './logger';
+import {TestLogger} from './logger';
 import * as trace from './trace';
 
 /**
@@ -38,7 +38,7 @@ function removeAllUncaughtExceptionListeners() {
 }
 
 describe('Trace Writer', () => {
-  const autoQueuedTrace = { traceId: '0', spans: [], projectId: '0' };
+  const autoQueuedTrace = {traceId: '0', spans: [], projectId: '0'};
   let capturedPublishedTraces: string;
   let capturedLogger: CaptureInstanceTestLogger;
 
@@ -81,14 +81,14 @@ describe('Trace Writer', () => {
 
   it(`should publish on unhandled exception for 'flush' config option`, done => {
     const restoreOriginalUncaughtExceptionListeners = removeAllUncaughtExceptionListeners();
-    trace.start({ onUncaughtException: 'flush', projectId: '0' });
+    trace.start({onUncaughtException: 'flush', projectId: '0'});
     setImmediate(() => {
       setImmediate(() => {
         removeAllUncaughtExceptionListeners();
         restoreOriginalUncaughtExceptionListeners();
         assert.strictEqual(
           capturedPublishedTraces,
-          JSON.stringify({ traces: [autoQueuedTrace] })
+          JSON.stringify({traces: [autoQueuedTrace]})
         );
         done();
       });
@@ -98,13 +98,13 @@ describe('Trace Writer', () => {
 
   it(`should not assign an oUE listener for 'ignore' config option`, () => {
     const restoreOriginalUncaughtExceptionListeners = removeAllUncaughtExceptionListeners();
-    trace.start({ onUncaughtException: 'ignore' });
+    trace.start({onUncaughtException: 'ignore'});
     assert.strictEqual(process.listenerCount('onHandledException'), 0);
     restoreOriginalUncaughtExceptionListeners();
   });
 
   it('should log and disable on invalid config values', () => {
-    trace.start({ onUncaughtException: 'invalidValue' });
+    trace.start({onUncaughtException: 'invalidValue'});
     assert.ok(capturedLogger);
     assert.strictEqual(
       capturedLogger.getNumLogsWith('error', 'Disabling the Trace Agent'),

--- a/test/test-trace-web-frameworks.ts
+++ b/test/test-trace-web-frameworks.ts
@@ -18,9 +18,9 @@ import * as assert from 'assert';
 import axiosModule from 'axios';
 import * as semver from 'semver';
 
-import { TraceSpan } from '../src/trace';
-import { TraceLabels } from '../src/trace-labels';
-import { StackFrame } from '../src/util';
+import {TraceSpan} from '../src/trace';
+import {TraceLabels} from '../src/trace-labels';
+import {StackFrame} from '../src/util';
 
 import * as testTraceModule from './trace';
 import {
@@ -29,13 +29,13 @@ import {
   isServerSpan,
   wait,
 } from './utils';
-import { WebFramework, WebFrameworkConstructor } from './web-frameworks/base';
-import { Connect3 } from './web-frameworks/connect';
-import { Express4 } from './web-frameworks/express';
-import { Hapi17 } from './web-frameworks/hapi17';
-import { Hapi12, Hapi15, Hapi16, Hapi8 } from './web-frameworks/hapi8_16';
-import { Koa1 } from './web-frameworks/koa1';
-import { Koa2 } from './web-frameworks/koa2';
+import {WebFramework, WebFrameworkConstructor} from './web-frameworks/base';
+import {Connect3} from './web-frameworks/connect';
+import {Express4} from './web-frameworks/express';
+import {Hapi17} from './web-frameworks/hapi17';
+import {Hapi12, Hapi15, Hapi16, Hapi8} from './web-frameworks/hapi8_16';
+import {Koa1} from './web-frameworks/koa1';
+import {Koa2} from './web-frameworks/koa2';
 import {
   Restify3,
   Restify4,
@@ -79,7 +79,7 @@ describe('Web framework tracing', () => {
   before(() => {
     testTraceModule.setCLSForTest();
     testTraceModule.setPluginLoaderForTest();
-    testTraceModule.start({ ignoreUrls: [/ignore-me/], ignoreMethods: [] });
+    testTraceModule.start({ignoreUrls: [/ignore-me/], ignoreMethods: []});
     axios = require('axios');
   });
 
@@ -107,7 +107,7 @@ describe('Web framework tracing', () => {
           hasResponse: true,
           fn: async () => {
             await wait(DEFAULT_SPAN_DURATION);
-            return { statusCode: 200, message: 'hello!' };
+            return {statusCode: 200, message: 'hello!'};
           },
         });
         webFramework.addHandler({
@@ -123,7 +123,7 @@ describe('Web framework tracing', () => {
           hasResponse: true,
           fn: async () => {
             await wait(DEFAULT_SPAN_DURATION / 2);
-            return { statusCode: 200, message: 'hellohello!!' };
+            return {statusCode: 200, message: 'hellohello!!'};
           },
         });
         webFramework.addHandler({
@@ -132,14 +132,14 @@ describe('Web framework tracing', () => {
           fn: async () => {
             await wait(0); // Add an additional link to the async execution chain.
             const response = await axios.get(`http://localhost:${port}/hello`);
-            return { statusCode: response.status, message: response.data };
+            return {statusCode: response.status, message: response.data};
           },
         });
         webFramework.addHandler({
           path: '/hello',
           hasResponse: true,
           fn: async () => {
-            return { statusCode: 200, message: '[incessant barking]' };
+            return {statusCode: 200, message: '[incessant barking]'};
           },
         });
         webFramework.addHandler({
@@ -153,7 +153,7 @@ describe('Web framework tracing', () => {
           path: '/ignore-me',
           hasResponse: true,
           fn: async () => {
-            return { statusCode: 200, message: '[unrestrained whimpering]' };
+            return {statusCode: 200, message: '[unrestrained whimpering]'};
           },
         });
         port = await webFramework.listen(0);
@@ -171,7 +171,7 @@ describe('Web framework tracing', () => {
         let recordedTime = 0;
         await testTraceModule
           .get()
-          .runInRootSpan({ name: 'outer' }, async span => {
+          .runInRootSpan({name: 'outer'}, async span => {
             assert.ok(testTraceModule.get().isRealSpan(span));
             recordedTime = Date.now();
             await axios.get(`http://localhost:${port}/one-handler`);
@@ -187,7 +187,7 @@ describe('Web framework tracing', () => {
         let recordedTime = 0;
         await testTraceModule
           .get()
-          .runInRootSpan({ name: 'outer' }, async span => {
+          .runInRootSpan({name: 'outer'}, async span => {
             assert.ok(testTraceModule.get().isRealSpan(span));
             recordedTime = Date.now();
             // Hit endpoint with two middlewares/handlers.
@@ -203,7 +203,7 @@ describe('Web framework tracing', () => {
       it('handles errors', async () => {
         await testTraceModule
           .get()
-          .runInRootSpan({ name: 'outer' }, async span => {
+          .runInRootSpan({name: 'outer'}, async span => {
             assert.ok(testTraceModule.get().isRealSpan(span));
             // Hit endpoint which always throws an error.
             await axios.get(`http://localhost:${port}/error`, {
@@ -222,7 +222,7 @@ describe('Web framework tracing', () => {
       it("doesn't trace ignored urls", async () => {
         await testTraceModule
           .get()
-          .runInRootSpan({ name: 'outer' }, async span => {
+          .runInRootSpan({name: 'outer'}, async span => {
             assert.ok(testTraceModule.get().isRealSpan(span));
             // Hit endpoint that always gets ignored.
             await axios.get(`http://localhost:${port}/ignore-me`);
@@ -235,7 +235,7 @@ describe('Web framework tracing', () => {
       it('ends span upon client abort', async () => {
         await testTraceModule
           .get()
-          .runInRootSpan({ name: 'outer' }, async span => {
+          .runInRootSpan({name: 'outer'}, async span => {
             assert.ok(testTraceModule.get().isRealSpan(span));
             // Hit endpoint, but time out before it has a chance to respond.
             // To ensure that a trace is written, also waits
@@ -277,7 +277,7 @@ describe('Web framework tracing', () => {
         // not get warnings for child spans.
         await testTraceModule
           .get()
-          .runInRootSpan({ name: 'outer', url: '/ignore-me' }, async span => {
+          .runInRootSpan({name: 'outer', url: '/ignore-me'}, async span => {
             requests = [
               axios.get(`http://localhost:${port}/hello?this-is=dog`),
               axios.get(`http://localhost:${port}/hello?this-is=puppy`),
@@ -294,7 +294,7 @@ describe('Web framework tracing', () => {
       it('propagates trace context', async () => {
         await testTraceModule
           .get()
-          .runInRootSpan({ name: 'outer' }, async span => {
+          .runInRootSpan({name: 'outer'}, async span => {
             assert.ok(testTraceModule.get().isRealSpan(span));
             // Hits endpoint that will make an additional outgoing HTTP
             // request (to another endpoint on the same server).
@@ -342,7 +342,7 @@ describe('Web framework tracing', () => {
         beforeEach(async () => {
           await testTraceModule
             .get()
-            .runInRootSpan({ name: 'outer' }, async span => {
+            .runInRootSpan({name: 'outer'}, async span => {
               assert.ok(testTraceModule.get().isRealSpan(span));
               // Hit an endpoint with a query parameter.
               await axios.get(`http://localhost:${port}/hello?this-is=dog`);
@@ -394,7 +394,7 @@ describe('Web framework tracing', () => {
         try {
           await testTraceModule
             .get()
-            .runInRootSpan({ name: 'outer' }, async span => {
+            .runInRootSpan({name: 'outer'}, async span => {
               assert.ok(testTraceModule.get().isRealSpan(span));
               await axios.get(`http://localhost:${port}/hello`);
               span!.endSpan();

--- a/test/test-trace-writer.ts
+++ b/test/test-trace-writer.ts
@@ -14,29 +14,25 @@
  * limitations under the License.
  */
 
-import { Service } from '@google-cloud/common';
+import {Service} from '@google-cloud/common';
 import * as assert from 'assert';
-import { GoogleAuth } from 'google-auth-library';
-import { JWTInput } from 'google-auth-library/build/src/auth/credentials';
-import { RefreshOptions } from 'google-auth-library/build/src/auth/oauth2client';
-import { OutgoingHttpHeaders } from 'http';
+import {GoogleAuth} from 'google-auth-library';
+import {JWTInput} from 'google-auth-library/build/src/auth/credentials';
+import {RefreshOptions} from 'google-auth-library/build/src/auth/oauth2client';
+import {OutgoingHttpHeaders} from 'http';
 import * as nock from 'nock';
 import * as os from 'os';
 import * as path from 'path';
-import { Response } from 'request'; // Only for type declarations.
+import {Response} from 'request'; // Only for type declarations.
 import * as shimmer from 'shimmer';
 
-import { SpanKind, Trace } from '../src/trace';
-import { TraceLabels } from '../src/trace-labels';
-import {
-  TraceBuffer,
-  TraceWriter,
-  TraceWriterConfig,
-} from '../src/trace-writer';
+import {SpanKind, Trace} from '../src/trace';
+import {TraceLabels} from '../src/trace-labels';
+import {TraceBuffer, TraceWriter, TraceWriterConfig} from '../src/trace-writer';
 
-import { TestLogger } from './logger';
-import { hostname, instanceId, oauth2 } from './nocks';
-import { wait } from './utils';
+import {TestLogger} from './logger';
+import {hostname, instanceId, oauth2} from './nocks';
+import {wait} from './utils';
 
 interface TestCredentials {
   client_id?: string;
@@ -104,7 +100,7 @@ describe('Trace Writer', () => {
   // endpoint nocked...
   let oauth2Scope: nock.Scope;
   // ...and allow one query to each of the two metadata endpoints per test.
-  let metadataScopes: { done: () => void; cancel: () => void };
+  let metadataScopes: {done: () => void; cancel: () => void};
 
   before(() => {
     nock.disableNetConnect();
@@ -224,7 +220,7 @@ describe('Trace Writer', () => {
     it(`doesn't call Service#getProjectId if project ID is passed`, async () => {
       const writer = new TraceWriter(
         Object.assign({}, DEFAULT_CONFIG, {
-          authOptions: { projectId: 'my-project' },
+          authOptions: {projectId: 'my-project'},
         }),
         logger
       );
@@ -328,7 +324,7 @@ describe('Trace Writer', () => {
     // When MockedRequestTraceWriter is used, this function dictates the
     // status code returned when Service#request is called.
     // By default, a 200 status code is always returned.
-    let overrideRequestResponse: () => Promise<{ statusCode: number }>;
+    let overrideRequestResponse: () => Promise<{statusCode: number}>;
     let capturedRequestOptions: DecorateRequestOptions | null = null;
     // We use this class to mock Service#request. Testing this function is the
     // responsibility of @google-cloud/common.
@@ -353,13 +349,13 @@ describe('Trace Writer', () => {
     }
 
     beforeEach(() => {
-      overrideRequestResponse = () => Promise.resolve({ statusCode: 200 });
+      overrideRequestResponse = () => Promise.resolve({statusCode: 200});
       capturedRequestOptions = null;
     });
 
     it('appends project ID and default labels to written traces', async () => {
       const writer = new MockedRequestTraceWriter(
-        Object.assign({}, DEFAULT_CONFIG, { bufferSize: 1 }),
+        Object.assign({}, DEFAULT_CONFIG, {bufferSize: 1}),
         logger
       );
       await writer.initialize();
@@ -384,7 +380,7 @@ describe('Trace Writer', () => {
     it(`doesn't enqueue open spans`, async () => {
       const NUM_SPANS = 5;
       const writer = new MockedRequestTraceWriter(
-        Object.assign({}, DEFAULT_CONFIG, { bufferSize: NUM_SPANS }),
+        Object.assign({}, DEFAULT_CONFIG, {bufferSize: NUM_SPANS}),
         logger
       );
       await writer.initialize();
@@ -417,7 +413,7 @@ describe('Trace Writer', () => {
       it('is satisfied when the number of enqueued spans >= bufferSize', async () => {
         const NUM_SPANS = 5;
         const writer = new MockedRequestTraceWriter(
-          Object.assign({}, DEFAULT_CONFIG, { bufferSize: NUM_SPANS }),
+          Object.assign({}, DEFAULT_CONFIG, {bufferSize: NUM_SPANS}),
           logger
         );
         await writer.initialize();
@@ -447,7 +443,7 @@ describe('Trace Writer', () => {
 
       it('is satisfied periodically', async () => {
         const writer = new MockedRequestTraceWriter(
-          Object.assign({}, DEFAULT_CONFIG, { flushDelaySeconds: 1 }),
+          Object.assign({}, DEFAULT_CONFIG, {flushDelaySeconds: 1}),
           logger
         );
         await writer.initialize();
@@ -468,7 +464,7 @@ describe('Trace Writer', () => {
     it('emits an error if there was an error publishing', async () => {
       overrideRequestResponse = () => Promise.reject(new Error());
       const writer = new MockedRequestTraceWriter(
-        Object.assign({}, DEFAULT_CONFIG, { bufferSize: 1 }),
+        Object.assign({}, DEFAULT_CONFIG, {bufferSize: 1}),
         logger
       );
       await writer.initialize();

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -15,13 +15,13 @@
  */
 
 import * as assert from 'assert';
-import { inspect } from 'util';
+import {inspect} from 'util';
 
-import { Constants } from '../src/constants';
-import { Logger } from '../src/logger';
+import {Constants} from '../src/constants';
+import {Logger} from '../src/logger';
 import * as util from '../src/util';
 
-import { TestLogger } from './logger';
+import {TestLogger} from './logger';
 
 const notNull = <T>(x: T | null | undefined): T => {
   assert.notStrictEqual(x, null);
@@ -57,10 +57,7 @@ describe('Singleton', () => {
     it('creates a new instance when [FORCE_NEW] is true in the config', () => {
       const singleton = new util.Singleton(MyClass);
       const createResult1 = singleton.create({}, logger);
-      const createResult2 = singleton.create(
-        { [util.FORCE_NEW]: true },
-        logger
-      );
+      const createResult2 = singleton.create({[util.FORCE_NEW]: true}, logger);
       assert.notStrictEqual(createResult1, createResult2);
     });
   });
@@ -80,7 +77,7 @@ describe('Singleton', () => {
     it('does not return a stale value', () => {
       const singleton = new util.Singleton(MyClass);
       singleton.create({}, logger);
-      const createResult = singleton.create({ [util.FORCE_NEW]: true }, logger);
+      const createResult = singleton.create({[util.FORCE_NEW]: true}, logger);
       const getResult = singleton.get();
       assert.strictEqual(getResult, createResult);
     });
@@ -89,7 +86,7 @@ describe('Singleton', () => {
 
 describe('util.lastOf', () => {
   it('should return the last non-null/undefined/NaN parameter', () => {
-    const { lastOf } = util;
+    const {lastOf} = util;
     assert.strictEqual(lastOf<number>(1), 1);
     assert.strictEqual(lastOf<number>(1, 2, null), 2);
     assert.strictEqual(lastOf<number>(1, null, 2), 2);
@@ -179,8 +176,8 @@ describe('util.parseContextFromHeader', () => {
 
 describe('util.generateTraceContext', () => {
   const inputs: util.TraceContext[] = [
-    { traceId: '123456', spanId: '667', options: 1 },
-    { traceId: '123456', spanId: '667', options: undefined },
+    {traceId: '123456', spanId: '667', options: 1},
+    {traceId: '123456', spanId: '667', options: undefined},
   ];
 
   inputs.forEach(s => {
@@ -224,12 +221,12 @@ describe('binary trace context', () => {
       description: 'trace context with 64-bit span ID',
     },
     {
-      structured: { traceId: commonTraceId, spanId: '1', options: 255 },
+      structured: {traceId: commonTraceId, spanId: '1', options: 255},
       binary: `0000${commonTraceId}01${'0000000000000001'}02${'ff'}`,
       description: 'trace context with 8-bit options',
     },
     {
-      structured: { traceId: commonTraceId, spanId: '1' },
+      structured: {traceId: commonTraceId, spanId: '1'},
       binary: `0000${commonTraceId}01${'0000000000000001'}02${'00'}`,
       description: 'trace context with no options',
     },
@@ -264,7 +261,7 @@ describe('binary trace context', () => {
         assert.deepStrictEqual(
           util.deserializeTraceContext(Buffer.from(testCase.binary, 'hex')),
           testCase.structured &&
-            Object.assign({ options: 0 }, testCase.structured)
+            Object.assign({options: 0}, testCase.structured)
         );
       })
     );

--- a/test/trace.ts
+++ b/test/trace.ts
@@ -38,22 +38,18 @@ import * as assert from 'assert';
 import * as shimmer from 'shimmer';
 
 import * as trace from '../src';
-import { Config, PluginTypes } from '../src';
-import { cls, TraceCLS, TraceCLSMechanism } from '../src/cls';
+import {Config, PluginTypes} from '../src';
+import {cls, TraceCLS, TraceCLSMechanism} from '../src/cls';
 import * as logger from '../src/logger';
-import { Trace, TraceSpan } from '../src/trace';
-import { PluginLoader, pluginLoader } from '../src/trace-plugin-loader';
-import {
-  TraceWriter,
-  traceWriter,
-  TraceWriterConfig,
-} from '../src/trace-writer';
-import { tracing, Tracing } from '../src/tracing';
-import { FORCE_NEW } from '../src/util';
+import {Trace, TraceSpan} from '../src/trace';
+import {PluginLoader, pluginLoader} from '../src/trace-plugin-loader';
+import {TraceWriter, traceWriter, TraceWriterConfig} from '../src/trace-writer';
+import {tracing, Tracing} from '../src/tracing';
+import {FORCE_NEW} from '../src/util';
 
 import * as testLogger from './logger';
 
-export { Config, PluginTypes };
+export {Config, PluginTypes};
 
 const traces: Trace[] = [];
 const spans: TraceSpan[] = [];
@@ -61,7 +57,7 @@ let capturedLogger: testLogger.TestLogger | null = null;
 
 export class TestCLS extends TraceCLS {
   constructor(config: {}, logger: logger.Logger) {
-    super({ mechanism: TraceCLSMechanism.NONE }, logger);
+    super({mechanism: TraceCLSMechanism.NONE}, logger);
   }
 }
 
@@ -113,7 +109,7 @@ export function start(projectConfig?: Config): PluginTypes.Tracer {
   capturedLogger = null;
   const agent = trace.start(
     Object.assign(
-      { samplingRate: 0, logLevel: 4, [FORCE_NEW]: true },
+      {samplingRate: 0, logLevel: 4, [FORCE_NEW]: true},
       projectConfig
     )
   );

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -20,13 +20,13 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as semver from 'semver';
 
-import { cls } from '../src/cls';
-import { OpenCensusPropagation } from '../src/config';
-import { SpanType } from '../src/constants';
-import { Span } from '../src/plugin-types';
-import { ChildSpanData, RootSpanData } from '../src/span-data';
-import { TraceSpan } from '../src/trace';
-import { StackdriverTracerConfig } from '../src/trace-api';
+import {cls} from '../src/cls';
+import {OpenCensusPropagation} from '../src/config';
+import {SpanType} from '../src/constants';
+import {Span} from '../src/plugin-types';
+import {ChildSpanData, RootSpanData} from '../src/span-data';
+import {TraceSpan} from '../src/trace';
+import {StackdriverTracerConfig} from '../src/trace-api';
 
 /**
  * Constants
@@ -131,8 +131,8 @@ interface PluginFixtures {
    * denoted by leading underscores.
    */
   [fixture: string]: {
-    dependencies: { [moduleName: string]: string };
-    engines?: { node?: string };
+    dependencies: {[moduleName: string]: string};
+    engines?: {node?: string};
     /**
      * If there are multiple top-level dependencies, specifies which one is the
      * "main" one
@@ -148,7 +148,7 @@ interface FixtureHelper<T> {
   /** The module version encapsulated by the fixture. */
   version: string;
   /** The parsed module version. */
-  parsedVersion: { major: number; minor: number; patch: number };
+  parsedVersion: {major: number; minor: number; patch: number};
   /** When called, loads the fixture. */
   require: () => T;
   /**
@@ -200,7 +200,7 @@ function getFixturesForModule<T>(moduleName: string): Array<FixtureHelper<T>> {
       const skip = (it: Mocha.TestFunction, versionRange: string) => {
         return semver.satisfies(version, versionRange) ? it.skip : it;
       };
-      return { version, parsedVersion, require: getModule, skip };
+      return {version, parsedVersion, require: getModule, skip};
     });
 }
 

--- a/test/web-frameworks/base.ts
+++ b/test/web-frameworks/base.ts
@@ -1,4 +1,4 @@
-import { IncomingHttpHeaders } from 'http';
+import {IncomingHttpHeaders} from 'http';
 
 /**
  * Copyright 2018 Google LLC

--- a/test/web-frameworks/connect.ts
+++ b/test/web-frameworks/connect.ts
@@ -15,9 +15,9 @@
  */
 
 import * as http from 'http';
-import { AddressInfo } from 'net';
+import {AddressInfo} from 'net';
 
-import { connect_3 } from '../../src/plugins/types';
+import {connect_3} from '../../src/plugins/types';
 
 import {
   WebFramework,

--- a/test/web-frameworks/express.ts
+++ b/test/web-frameworks/express.ts
@@ -15,9 +15,9 @@
  */
 
 import * as http from 'http';
-import { AddressInfo } from 'net';
+import {AddressInfo} from 'net';
 
-import { express_4 } from '../../src/plugins/types';
+import {express_4} from '../../src/plugins/types';
 
 import {
   WebFramework,

--- a/test/web-frameworks/hapi17.ts
+++ b/test/web-frameworks/hapi17.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 
-import { hapi_17 } from '../../src/plugins/types';
+import {hapi_17} from '../../src/plugins/types';
 
 import {
   WebFramework,

--- a/test/web-frameworks/hapi8_16.ts
+++ b/test/web-frameworks/hapi8_16.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 
-import { hapi_16 } from '../../src/plugins/types';
+import {hapi_16} from '../../src/plugins/types';
 
 import {
   WebFramework,
@@ -80,7 +80,7 @@ export class Hapi extends EventEmitter implements WebFramework {
   }
 
   async listen(port: number): Promise<number> {
-    this.server.connection({ host: 'localhost', port });
+    this.server.connection({host: 'localhost', port});
     this.queuedHandlers.forEach(fn => fn());
     this.queuedHandlers = [];
     await new Promise((resolve, reject) =>

--- a/test/web-frameworks/koa1.ts
+++ b/test/web-frameworks/koa1.ts
@@ -15,9 +15,9 @@
  */
 
 import * as http from 'http';
-import { AddressInfo } from 'net';
+import {AddressInfo} from 'net';
 
-import { koa_1 } from '../../src/plugins/types';
+import {koa_1} from '../../src/plugins/types';
 import * as testTraceModule from '../trace';
 
 import {

--- a/test/web-frameworks/koa2.ts
+++ b/test/web-frameworks/koa2.ts
@@ -15,11 +15,11 @@
  */
 
 import * as http from 'http';
-import { AddressInfo } from 'net';
+import {AddressInfo} from 'net';
 
-import { koa_2 as Koa } from '../../src/plugins/types';
+import {koa_2 as Koa} from '../../src/plugins/types';
 
-import { WebFramework, WebFrameworkAddHandlerOptions } from './base';
+import {WebFramework, WebFrameworkAddHandlerOptions} from './base';
 
 export class Koa2 implements WebFramework {
   static commonName = 'koa@2';

--- a/test/web-frameworks/restify.ts
+++ b/test/web-frameworks/restify.ts
@@ -16,7 +16,7 @@
 
 import * as http from 'http';
 
-import { restify_5 } from '../../src/plugins/types';
+import {restify_5} from '../../src/plugins/types';
 
 import {
   WebFramework,


### PR DESCRIPTION
This adds the prettier config we use in all of the other client libs, and runs `gts fix`. 