### PR TITLE
build: fix `npm run get-plugin-types` on windows

### DIFF
--- a/scripts/get-plugin-types.ts
+++ b/scripts/get-plugin-types.ts
@@ -20,7 +20,7 @@ export async function getPluginTypes() {
   const indexTs = (await readFileP(`${TYPES_DIRECTORY}/index.d.ts`, 'utf8') as string)
     .split('\n');
   for (const line of indexTs) {
-    const matches = line.match(/^import \* as .* from '\.\/(.+)';\s*\/\/\s*(.+)@(.+)$/);
+    const matches = line.match(/^import \* as .* from '\.\/(.+)';\s*\/\/\s*(.+)@(.+)/);
     if (!matches) {
       continue;
     }


### PR DESCRIPTION
`.` appears not to match `\r` in a regex, so `get-plugin-types` won't work on Windows if git is configured to use CRLFs.

__Note__: Kokoro CI results can be ignored