### PR TITLE
build: mark some new tests as integration tests

### DIFF
--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -32,9 +32,11 @@ const keyID = 'a179efbeda21';
 const unitTestExcludeGlobs: string[] = TRACE_TEST_EXCLUDE_INTEGRATION ? [
   `${BUILD_DIRECTORY}/test/plugins/test-*`,
   `${BUILD_DIRECTORY}/test/test-agent-stopped.js`,
+  `${BUILD_DIRECTORY}/test/test-grpc-async-handler.js`,
   `${BUILD_DIRECTORY}/test/test-grpc-context.js`,
   `${BUILD_DIRECTORY}/test/test-mysql-pool.js`,
   `${BUILD_DIRECTORY}/test/test-plugins-*`,
+  `${BUILD_DIRECTORY}/test/test-trace-hapi-tails.js`,
   `${BUILD_DIRECTORY}/test/test-trace-web-frameworks.js`,
   `${BUILD_DIRECTORY}/test/test-unpatch.js`
 ] : [];


### PR DESCRIPTION
These tests have been added since `TRACE_TEST_EXCLUDE_INTEGRATION` has last been put into use (on Appveyor). This change is needed for CI environments where spinning up docker containers is difficult.

__Note__: Kokoro CI results can be ignored