### PR TITLE
test: relax aborted span test

### DIFF
--- a/test/test-trace-web-frameworks.ts
+++ b/test/test-trace-web-frameworks.ts
@@ -51,7 +51,7 @@ interface TraceSpanStackFrames {
 }
 
 // The number of times to retry counting spans in the aborted request test
-const ABORTED_SPAN_RETRIES = 3;
+const ABORTED_SPAN_RETRIES = 5;
 // The list of web frameworks to test.
 const FRAMEWORKS: WebFrameworkConstructor[] = [
   Connect3,


### PR DESCRIPTION
The aborted span test is the # 1 cause of flakes. By waiting 1000ms instead of 600ms, I hope this will reduce the number of flaky results.