### PR TITLE
feat: support @hapi/hapi

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -334,6 +334,7 @@ export const defaultConfig = {
     'generic-pool': path.join(pluginDirectory, 'plugin-generic-pool.js'),
     grpc: path.join(pluginDirectory, 'plugin-grpc.js'),
     hapi: path.join(pluginDirectory, 'plugin-hapi.js'),
+    '@hapi/hapi': path.join(pluginDirectory, 'plugin-hapi.js'),
     http: path.join(pluginDirectory, 'plugin-http.js'),
     http2: path.join(pluginDirectory, 'plugin-http2.js'),
     koa: path.join(pluginDirectory, 'plugin-koa.js'),

--- a/src/plugins/plugin-hapi.ts
+++ b/src/plugins/plugin-hapi.ts
@@ -133,7 +133,7 @@ const plugin: PluginTypes.Plugin = [
    * available in every handler.
    */
   {
-    versions: '17',
+    versions: '>=17',
     file: 'lib/request.js',
     // Request is a class name.
     // tslint:disable-next-line:variable-name

--- a/test/fixtures/plugin-fixtures.json
+++ b/test/fixtures/plugin-fixtures.json
@@ -59,6 +59,11 @@
       "hapi": "^17.0.0"
     }
   },
+  "hapi18": {
+    "dependencies": {
+      "@hapi/hapi": "^18.0.0"
+    }
+  },
   "hapi8": {
     "dependencies": {
       "hapi": "^8.8.1"

--- a/test/test-config-plugins.ts
+++ b/test/test-config-plugins.ts
@@ -22,6 +22,18 @@ import {PluginLoader, PluginLoaderConfig} from '../src/trace-plugin-loader';
 
 import * as testTraceModule from './trace';
 
+function assertPluginPath(
+  plugins: {[pluginName: string]: string},
+  pluginName: string
+) {
+  // hapi was renamed to @hapi/hapi in v18. We still use the same plugin
+  // filename.
+  if (pluginName === '@hapi/hapi') {
+    pluginName = 'hapi';
+  }
+  assert.ok(plugins[pluginName].includes(`plugin-${pluginName}.js`));
+}
+
 describe('Configuration: Plugins', () => {
   const instrumentedModules = Object.keys(defaultConfig.plugins);
   let plugins: {[pluginName: string]: string} | null;
@@ -55,9 +67,7 @@ describe('Configuration: Plugins', () => {
       JSON.stringify(Object.keys(plugins!)),
       JSON.stringify(instrumentedModules)
     );
-    instrumentedModules.forEach(e =>
-      assert.ok(plugins![e].includes(`plugin-${e}.js`))
-    );
+    instrumentedModules.forEach(e => assertPluginPath(plugins!, e));
   });
 
   it('should handle empty object', () => {
@@ -67,9 +77,7 @@ describe('Configuration: Plugins', () => {
       JSON.stringify(Object.keys(plugins!)),
       JSON.stringify(instrumentedModules)
     );
-    instrumentedModules.forEach(e =>
-      assert.ok(plugins![e].includes(`plugin-${e}.js`))
-    );
+    instrumentedModules.forEach(e => assertPluginPath(plugins!, e));
   });
 
   it('should handle non-object', () => {
@@ -86,7 +94,7 @@ describe('Configuration: Plugins', () => {
     );
     instrumentedModules
       .filter(e => e !== 'express')
-      .forEach(e => assert.ok(plugins![e].includes(`plugin-${e}.js`)));
+      .forEach(e => assertPluginPath(plugins!, e));
     assert.strictEqual(plugins!.express, 'foo');
   });
 });

--- a/test/test-trace-web-frameworks.ts
+++ b/test/test-trace-web-frameworks.ts
@@ -32,7 +32,7 @@ import {
 import {WebFramework, WebFrameworkConstructor} from './web-frameworks/base';
 import {Connect3} from './web-frameworks/connect';
 import {Express4} from './web-frameworks/express';
-import {Hapi17} from './web-frameworks/hapi17';
+import {Hapi17, Hapi18} from './web-frameworks/hapi17';
 import {Hapi12, Hapi15, Hapi16, Hapi8} from './web-frameworks/hapi8_16';
 import {Koa1} from './web-frameworks/koa1';
 import {Koa2} from './web-frameworks/koa2';
@@ -61,6 +61,7 @@ const FRAMEWORKS: WebFrameworkConstructor[] = [
   Hapi15,
   Hapi16,
   Hapi17,
+  Hapi18,
   Koa1,
   Koa2,
   Restify3,


### PR DESCRIPTION
Fixes #1107

This PR adds support for hapi 18 (now `@hapi/hapi`).

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
