### PR TITLE
fix: unpin @types/node and account for new http.request signatures

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@types/mocha": "^5.2.5",
     "@types/mongoose": "^5.3.26",
     "@types/nock": "^10.0.0",
-    "@types/node": "~10.7.2",
+    "@types/node": "^12.7.2",
     "@types/node-fetch": "^2.5.0",
     "@types/once": "^1.4.0",
     "@types/proxyquire": "^1.3.28",

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -44,7 +44,7 @@ function promisifyChildProcess(childProcess: ChildProcess): Promise<void> {
   });
 }
 
-export function spawnP(command: string, args?: string[], options?: SpawnOptions): Promise<void> {
+export function spawnP(command: string, args: string[] = [], options: SpawnOptions = {}): Promise<void> {
   const stringifiedCommand = `\`${command}${args ? (' ' + args.join(' ')) : ''}\``;
   console.log(`> Running: ${stringifiedCommand}`);
   return promisifyChildProcess(spawn(command, args, Object.assign({
@@ -53,7 +53,7 @@ export function spawnP(command: string, args?: string[], options?: SpawnOptions)
   }, options)));
 }
 
-export function forkP(moduleName: string, args?: string[], options?: ForkOptions): Promise<void> {
+export function forkP(moduleName: string, args: string[] = [], options: ForkOptions = {}): Promise<void> {
   const stringifiedCommand = `\`${moduleName}${args ? (' ' + args.join(' ')) : ''}\``;
   console.log(`> Running: ${stringifiedCommand}`);
   return promisifyChildProcess(fork(moduleName, args, Object.assign({

--- a/src/plugins/plugin-koa.ts
+++ b/src/plugins/plugin-koa.ts
@@ -121,7 +121,10 @@ function createMiddleware(api: PluginTypes.Tracer): koa_1.Middleware {
   return function* middleware(this: koa_1.Context, next: IterableIterator<{}>) {
     next = startSpanForRequest(api, this, (propagateContext: boolean) => {
       if (propagateContext) {
-        next.next = api.wrap(next.next);
+        // TS Iterator definition clashes with @types/node.
+        // For some reason, this causes the next line to not pass type check.
+        // tslint:disable-next-line:no-any
+        next.next = api.wrap(next.next as any);
       }
       return next;
     });

--- a/test/test-cls-ah.ts
+++ b/test/test-cls-ah.ts
@@ -35,29 +35,31 @@ maybeSkip(describe)('AsyncHooks-based CLS', () => {
   before(() => {
     asyncHooks = require('async_hooks') as AsyncHooksModule;
     AsyncResource = class extends asyncHooks.AsyncResource {
+      // Polyfill for versions in which runInAsyncScope isn't defined.
+      // This can be removed when it's guaranteed that runInAsyncScope is
+      // present on AsyncResource.
       // tslint:disable:no-any
       runInAsyncScope<This, Result>(
         fn: (this: This, ...args: any[]) => Result,
         thisArg?: This
       ): Result {
-        // tslint:enable:no-any
-        // Polyfill for versions in which runInAsyncScope isn't defined
         if (super.runInAsyncScope) {
           return super.runInAsyncScope.apply(this, arguments);
         } else {
           // tslint:disable:deprecation
-          this.emitBefore();
+          (this as any).emitBefore();
           try {
             return fn.apply(
               thisArg,
               Array.prototype.slice.apply(arguments).slice(2)
             );
           } finally {
-            this.emitAfter();
+            (this as any).emitAfter();
           }
           // tslint:enable:deprecation
         }
       }
+      // tslint:enable:no-any
     };
   });
 


### PR DESCRIPTION
This PR adds support for a new signature of `http.request` in Node 10.9+. It also unpins `@types/node`.