### PR TITLE
chore: invalidate circleci cache nightly; cache node_modules again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,9 @@
 ---
 # Constant values.
 
-test_fixtures_cache_key: &test_fixtures_cache_key test-fixtures-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "test/fixtures/plugin-fixtures.json" }}
-plugin_types_cache_key: &plugin_types_cache_key plugin-types-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "src/plugins/types/index.d.ts" }}
+node_modules_cache_key: &node_modules_cache_key node-modules-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "package.json" }}-{{ checksum "date" }}
+test_fixtures_cache_key: &test_fixtures_cache_key test-fixtures-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "test/fixtures/plugin-fixtures.json" }}-{{ checksum "date" }}
+plugin_types_cache_key: &plugin_types_cache_key plugin-types-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "src/plugins/types/index.d.ts" }}-{{ checksum "date" }}
 release_tags: &release_tags
   tags:
     only: /^v\d+(\.\d+){2}(-.*)?$/
@@ -13,13 +14,22 @@ unit_tests: &unit_tests
   steps:
     - checkout
     - run:
+        name: Get the current data for cache keys
+        command: date +%F > date
+    - run:
         name: Configure npm to allow running scripts as root
         command: npm config set unsafe-perm true
+    - restore_cache:
+        key: *node_modules_cache_key
     - restore_cache:
         key: *plugin_types_cache_key
     - run:
         name: Install modules and dependencies
         command: npm install
+    - save_cache:
+        key: *node_modules_cache_key
+        paths:
+          - node_modules
     - save_cache:
         key: *plugin_types_cache_key
         paths:


### PR DESCRIPTION
Fixes #1119

This allows us to discover breakages due to external changes from nightly runs, and also should make non-nightly tests run faster.