### PR TITLE
test: don't override event emitters

### DIFF
--- a/test/test-trace-hapi-tails.ts
+++ b/test/test-trace-hapi-tails.ts
@@ -83,7 +83,7 @@ describe('Web framework tracing', () => {
           });
           // A Promise that resolves when the tail call is finished.
           const tailCallMade = new Promise(resolve =>
-            framework.once('tail', resolve)
+            framework.events.once('tail', resolve)
           );
           // Start listening.
           const port = await framework.listen(0);

--- a/test/web-frameworks/hapi17.ts
+++ b/test/web-frameworks/hapi17.ts
@@ -26,7 +26,9 @@ interface AppState {
   [TAIL_WORK]?: Array<Promise<void>>;
 }
 
-class Hapi extends EventEmitter implements WebFramework {
+class Hapi implements WebFramework {
+  // Only used in Hapi tails test.
+  events: EventEmitter = new EventEmitter();
   server: hapi_17.Server;
   // We can't add two routes on the same path.
   // So instead of registering a new Hapi plugin per path,
@@ -36,13 +38,12 @@ class Hapi extends EventEmitter implements WebFramework {
   registering = Promise.resolve();
 
   constructor(path: string) {
-    super();
     const hapi = require(path) as typeof hapi_17;
     this.server = new hapi.Server();
     this.server.events.on('response', (request: hapi_17.Request) => {
       Promise.all((request.app as AppState)[TAIL_WORK] || []).then(
-        () => this.emit('tail'),
-        (err: Error) => this.emit('tail', err)
+        () => this.events.emit('tail'),
+        (err: Error) => this.events.emit('tail', err)
       );
     });
   }

--- a/test/web-frameworks/hapi8_16.ts
+++ b/test/web-frameworks/hapi8_16.ts
@@ -24,7 +24,9 @@ import {
   WebFrameworkResponse,
 } from './base';
 
-export class Hapi extends EventEmitter implements WebFramework {
+export class Hapi implements WebFramework {
+  // Only used in Hapi tails test.
+  events: EventEmitter = new EventEmitter();
   server: hapi_16.Server;
   // In Hapi, handlers are added after a connection is specified.
   // Since a port number is required to initialize a connection,
@@ -33,10 +35,9 @@ export class Hapi extends EventEmitter implements WebFramework {
   queuedHandlers: Array<() => void> = [];
 
   constructor(path: string) {
-    super();
     const hapi = require(path) as typeof hapi_16;
     this.server = new hapi.Server();
-    this.server.on('tail', () => this.emit('tail'));
+    this.server.on('tail', () => this.events.emit('tail'));
   }
 
   addHandler(options: WebFrameworkAddHandlerOptions): void {


### PR DESCRIPTION
New TS definitions for `events` doesn't allow anonymous subclasses of `EventEmitter` (or something like that), so compilation broke a little. This PR fixes that.