### PR TITLE
fix: sample app TypeError

### DIFF
--- a/samples/app.js
+++ b/samples/app.js
@@ -31,7 +31,7 @@ const DISCOVERY_URL = 'https://www.googleapis.com/discovery/v1/apis';
 app.get('/', async (req, res) => {
   // This outgoing HTTP request should be captured by Trace
   try {
-    const {body} = await got(DISCOVERY_URL, {json: true});
+    const {body} = await got(DISCOVERY_URL, {responseType: 'json'});
     const names = body.items.map(item => item.name);
     res.status(200).send(names.join('\n')).end();
   } catch (err) {


### PR DESCRIPTION
App sample has error: TypeError: The `GET` method cannot be used with a body
This pull request is to update the body to an json response option

Fixes #1246 🦕
