### PR TITLE
Change Windows CI to use Node.js 10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 10
       - run: npm install
       - run: npm test
       - name: coverage


### PR DESCRIPTION
Workaround for issue discussed here: https://github.com/nodejs/node/issues/33254

Should be possible to revert once Node.js 12.16.3 is released.
