### PR TITLE
chore(deps): we no longer use standard-version for releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "nock": "^12.0.0",
     "once": "^1.4.0",
     "retry-axios": "^2.0.0",
-    "standard-version": "^7.0.0",
     "teeny-request": "^6.0.0",
     "timekeeper": "^2.0.0",
     "tmp": "0.2.1",


### PR DESCRIPTION
Releases are now automated, _also based on Conventional Commits_, but we should no longer need `standard-version` (which did the same thing when run manually.