### PR TITLE
Revert "build(node): remove unused tokens"

### DIFF
--- a/.kokoro/release/publish.cfg
+++ b/.kokoro/release/publish.cfg
@@ -1,8 +1,48 @@
+# Get npm token from Keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "google_cloud_npm_token"
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "yoshi-automation-github-key"
+    }
+  }
+}
+
 before_action {
   fetch_keystore {
     keystore_resource {
       keystore_config_id: 73713
       keyname: "docuploader_service_account"
+    }
+  }
+}
+
+# Fetch magictoken to use with Magic Github Proxy
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "releasetool-magictoken"
+    }
+  }
+}
+
+# Fetch api key to use with Magic Github Proxy
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "magic-github-proxy-api-key"
     }
   }
 }

--- a/synth.metadata
+++ b/synth.metadata
@@ -4,14 +4,14 @@
       "git": {
         "name": ".",
         "remote": "https://github.com/googleapis/cloud-trace-nodejs.git",
-        "sha": "3e529c8813e44d036364b432c9dbece00fccf26a"
+        "sha": "cbdbb6c4e75881a497393733563d7e42a4c3805f"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "b33b0e2056a85fc2264b294f2cf47dcd45e95186"
+        "sha": "57c23fa5705499a4181095ced81f0ee0933b64f6"
       }
     }
   ]


### PR DESCRIPTION
Reverts googleapis/cloud-trace-nodejs#1340. Tests broke right after this change, so I am checking to see if this fixes the tests.