### PR TITLE
build: remove mongoose types

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@types/knex": "^0.15.1",
     "@types/methods": "^1.1.0",
     "@types/mocha": "^8.0.0",
-    "@types/mongoose": "^5.3.26",
     "@types/node": "^14.0.0",
     "@types/node-fetch": "^2.5.0",
     "@types/once": "^1.4.0",

--- a/src/plugins/plugin-mongoose.ts
+++ b/src/plugins/plugin-mongoose.ts
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// eslint-disable-next-line node/no-extraneous-import
-import * as mongooseTypes from 'mongoose';
 import {PluginTypes} from '..';
 
 const plugin: PluginTypes.Plugin = [
   {
     versions: '4 - 5',
     file: 'lib/query.js',
-    intercept: (Query: typeof mongooseTypes.Query, api) => {
+    intercept: (Query: Function, api) => {
       // Assume that the context desired at Query execution time should be the
       // context where the Query object was constructed. In most (if not all)
       // Mongoose read APIs, both of these appear to happen as part of the same

--- a/test/plugins/test-trace-mongoose-async-await.ts
+++ b/test/plugins/test-trace-mongoose-async-await.ts
@@ -14,9 +14,6 @@
 
 import * as assert from 'assert';
 import {it, before, after, afterEach} from 'mocha';
-// eslint-disable-next-line node/no-extraneous-import
-import * as mongooseTypes from 'mongoose';
-
 import * as traceTestModule from '../trace';
 import {describeInterop} from '../utils';
 
@@ -26,10 +23,11 @@ interface TestDocType {
   f3: number;
 }
 
-describeInterop<typeof mongooseTypes>('mongoose', fixture => {
-  let mongoose: typeof mongooseTypes;
-  // Simple will be treated as a class constructor.
-  let Simple: mongooseTypes.Model<mongooseTypes.Document & TestDocType>;
+describeInterop('mongoose', fixture => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mongoose: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Simple: any;
 
   /**
    * Common logic used in multiple tests -- inserts an object into the database.
@@ -54,10 +52,7 @@ describeInterop<typeof mongooseTypes>('mongoose', fixture => {
 
     const {Schema} = mongoose;
     const simpleSchema = new Schema({f1: String, f2: Boolean, f3: Number});
-    Simple = mongoose.model<mongooseTypes.Document & TestDocType>(
-      'Simple',
-      simpleSchema
-    );
+    Simple = mongoose.model('Simple', simpleSchema);
   });
 
   after(async () => {


### PR DESCRIPTION
Builds are currently failing on main.  This is due to a TypeScript compilation error related to a buried `.d.ts` file for `mongodb`, which comes in as a transitive dependency of `@types/mongoose`.  In recent releases, `mongoose` started shipping their own `d.ts` files, but they require a later version of TypeScript than we're currently using.  Updating the version of TypeScript could be a user breaking change, and when I tried - it created a whole bunch of other problems.  These types are only used in the tests, so I chose to remove the types dependency to fix the build, and sprinkle some `any` on it. 

![image](https://user-images.githubusercontent.com/534619/132896897-e6eb06d8-5005-4504-b11a-9a9b11a6a59f.png)
