### PR TITLE
meta: update repo metadata to reflect new team name and product rebranding

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs @googleapis/api-trace
+*     @googleapis/yoshi-nodejs @googleapis/google-cloud-trace
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "trace",
-  "name_pretty": "Stackdriver Trace",
+  "name_pretty": "Cloud Trace",
   "product_documentation": "https://cloud.google.com/trace",
   "client_documentation": "https://cloud.google.com/nodejs/docs/reference/trace-agent/latest",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559776",
@@ -9,5 +9,5 @@
   "repo": "googleapis/cloud-trace-nodejs",
   "distribution_name": "@google-cloud/trace-agent",
   "api_id": "cloudtrace.googleapis.com",
-  "codeowner_team": "@googleapis/api-trace"
+  "codeowner_team": "@googleapis/google-cloud-trace"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ accept your pull requests.
 ### Before you begin
 
 1.  [Select or create a Cloud Platform project][projects]. 
-1.  [Enable the Stackdriver Trace API][enable_api]. 
+1.  [Enable the Cloud Trace API][enable_api]. 
 1.  [Set up authentication with a service account][auth] so you can access the
     API from your local workstation.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [//]: # "To regenerate it, use `python -m synthtool`."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [Stackdriver Trace: Node.js Client](https://github.com/googleapis/cloud-trace-nodejs)
+# [Cloud Trace: Node.js Client](https://github.com/googleapis/cloud-trace-nodejs)
 
 [![release level](https://img.shields.io/badge/release%20level-beta-yellow.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
 [![npm version](https://img.shields.io/npm/v/@google-cloud/trace-agent.svg)](https://www.npmjs.org/package/@google-cloud/trace-agent)
@@ -17,8 +17,8 @@ Node.js Support for StackDriver Trace
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG](https://github.com/googleapis/cloud-trace-nodejs/blob/main/CHANGELOG.md).
 
-* [Stackdriver Trace Node.js Client API Reference][client-docs]
-* [Stackdriver Trace Documentation][product-docs]
+* [Cloud Trace Node.js Client API Reference][client-docs]
+* [Cloud Trace Documentation][product-docs]
 * [github.com/googleapis/cloud-trace-nodejs](https://github.com/googleapis/cloud-trace-nodejs)
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -43,7 +43,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 ### Before you begin
 
 1.  [Select or create a Cloud Platform project][projects].
-1.  [Enable the Stackdriver Trace API][enable_api].
+1.  [Enable the Cloud Trace API][enable_api].
 1.  [Set up authentication with a service account][auth] so you can access the
     API from your local workstation.
 
@@ -227,7 +227,7 @@ Samples are in the [`samples/`](https://github.com/googleapis/cloud-trace-nodejs
 
 
 
-The [Stackdriver Trace Node.js Client API Reference][client-docs] documentation
+The [Cloud Trace Node.js Client API Reference][client-docs] documentation
 also contains samples.
 
 ## Supported Node.js Versions

--- a/samples/README.md
+++ b/samples/README.md
@@ -2,7 +2,7 @@
 [//]: # "To regenerate it, use `python -m synthtool`."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# [Stackdriver Trace: Node.js Samples](https://github.com/googleapis/cloud-trace-nodejs)
+# [Cloud Trace: Node.js Samples](https://github.com/googleapis/cloud-trace-nodejs)
 
 [![Open in Cloud Shell][shell_img]][shell_link]
 


### PR DESCRIPTION
This updates the repo metadata for github.com/googleapis/cloud-trace-nodejs to set the team owner to the TeamSync team "google-cloud-trace". This change also modernizes the product name, reflecting the current product branding (GCP removed the "Stackdriver" brand from the various Ops Management products a little over a year ago).