### PR TITLE
chore: pin some dependency versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     # Docker containers to run for database RPC tracing integration tests.
     services:
       mongo:
-        image: mongo
+        image: mongo:5
         ports:
           - 27017:27017
       mysql:

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/proxyquire": "^1.3.28",
     "@types/semver": "^7.0.0",
     "@types/shimmer": "^1.0.1",
-    "@types/source-map-support": "^0.5.1",
+    "@types/source-map-support": "0.5.1",
     "@types/tmp": "0.2.3",
     "@types/uuid": "^8.0.0",
     "axios": "^0.27.0",
@@ -87,7 +87,7 @@
     "timekeeper": "^2.0.0",
     "tmp": "0.2.1",
     "ts-node": "^10.7.0",
-    "typescript": "^4.6.4"
+    "typescript": "~4.7"
   },
   "dependencies": {
     "@google-cloud/common": "^4.0.0",


### PR DESCRIPTION
Specifically, we grabbed

* TS 4.8 with https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#unconstrained-generics-no-longer-assignable-to
* @types/source-map-support with https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61841
* MongoDB 6 with https://www.mongodb.com/docs/v6.0/release-notes/6.0-compatibility/#legacy-opcodes-removed
